### PR TITLE
 ci: add markdown lint

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -78,6 +78,18 @@ jobs:
       - name: govulncheck
         uses: golang/govulncheck-action@v1
 
+  markdownlint:
+    name: markdownlint
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+    - uses: DavidAnson/markdownlint-cli2-action@v16
+      with:
+        config: .markdownlint.yaml
+        globs: 'docs/*.md'
+
   shellcheck:
     name: Shellcheck
     runs-on: ubuntu-latest

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,16 @@
+MD010: false # Hard tabs
+MD012: false # Multiple consecutive blank lines
+MD013: false # Line length
+MD019: false # Multiple spaces after hash on atx style heading
+MD021: false # Multiple spaces inside hashes on closed atx style heading
+MD022: false # Headings should be surrounded by blank lines
+MD024: false # Multiple headings with the same content
+MD025: false # Multiple top-level headings in the same document
+MD027: false # Multiple spaces after blockquote symbol
+MD030: false # Spaces after list markers
+MD031: false # Fenced code blocks should be surrounded by blank lines
+MD032: false # Lists should be surrounded by blank lines
+MD041: false # First line in a file should be a top-level heading
+MD043: false # Required heading structure
+MD045: false # Images should have alternate text (alt text)
+MD053: false # Link and image reference definitions should be needed

--- a/docs/coding.md
+++ b/docs/coding.md
@@ -18,7 +18,7 @@ Here's a list of some more specific conventions that are often followed in the c
 
 We use the following convention for specifying imports:
 
-```
+```text
 <import standard library packages>
 
 <import ceph-csi-operator packages>

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -68,7 +68,7 @@ By contributing to this project you agree to the Developer Certificate of Origin
 
 Contributors sign-off that they adhere to these requirements by adding a Signed-off-by line to commit messages. For example:
 
-```
+```text
 This is my commit message
 
 More details on what this commit does
@@ -88,7 +88,7 @@ We use a [DCO bot](https://github.com/apps/dco) to enforce the DCO on each pull 
 
 We follow a rough convention for commit messages that is designed to answer two questions: what changed and why? The subject line should feature the what and the body of the commit should describe the why.
 
-```
+```text
 fix bug in configmap
 
 fix clusterID bug in the configmap where the clusterID is
@@ -99,7 +99,7 @@ Signed-off-by: Random J Developer <random@developer.example.org>
 
 The format can be described more formally as follows:
 
-```
+```text
 <subject of the change>
 <BLANK LINE>
 <paragraph(s) with reason/description>
@@ -111,19 +111,19 @@ The first line is the subject and should be no longer than 70 characters, the se
 
 Here is a short guide on how to work on a new patch. In this example, we will work on a patch called *hellopatch*:
 
-1. Make sure you Frok's main branch is up to date
+1. Make sure you Fork's main branch is up to date
 
-```console
-git fetch upstream main:main
-git checkout main
-git push
-```
+    ```console
+    git fetch upstream main:main
+    git checkout main
+    git push
+    ```
 
 2. Create a new branch for your patch:
 
-```console
-git checkout -b hellopatch
-```
+    ```console
+    git checkout -b hellopatch
+    ```
 
 Do your work here and commit.
 


### PR DESCRIPTION
adding markdown lint CI check and also adding some small changes
to fix the CI

```
MD010: false # Hard tabs
MD012: false # Multiple consecutive blank lines
MD013: false # Line length
MD019: false # Multiple spaces after hash on atx style heading
MD021: false # Multiple spaces inside hashes on closed atx style heading
MD022: false # Headings should be surrounded by blank lines
MD024: false # Multiple headings with the same content
MD025: false # Multiple top-level headings in the same document
MD027: false # Multiple spaces after blockquote symbol
MD030: false # Spaces after list markers
MD031: false # Fenced code blocks should be surrounded by blank lines
MD032: false # Lists should be surrounded by blank lines
MD041: false # First line in a file should be a top-level heading
MD043: false # Required heading structure
MD045: false # Images should have alternate text (alt text)
MD053: false # Link and image reference definitions should be needed
```