### PR TITLE
Diable golangci-lint gocyclo

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,7 +23,6 @@ linters:
     - errcheck
     - exportloopref
     - goconst
-    - gocyclo
     - gofmt
     - goimports
     - gosimple


### PR DESCRIPTION
Discussed between repo maintainers and key contributors and agreed to opt-out of gocyclo

# Describe what this PR does #

The PR removes gocyclo from the list of enabled linters for golangci-lint