### PR TITLE
logrotate: add logrotate functionality for csi

### DIFF
--- a/api/v1alpha1/driver_types.go
+++ b/api/v1alpha1/driver_types.go
@@ -33,8 +33,10 @@ const (
 	MonthlyPeriod PeriodicityType = "monthly"
 )
 
+// +kubebuilder:validation:XValidation:message="Either maxLogSize or periodicity must be set",rule="(has(self.maxLogSize)) || (has(self.periodicity))"
 type LogRotationSpec struct {
 	// MaxFiles is the number of logrtoate files
+	// Default to 7
 	//+kubebuilder:validation:Optional
 	MaxFiles int `json:"maxFiles,omitempty"`
 
@@ -48,6 +50,7 @@ type LogRotationSpec struct {
 	Periodicity PeriodicityType `json:"periodicity,omitempty"`
 
 	// LogHostPath is the prefix directory path for the csi log files
+	// Default to /var/lib/cephcsi
 	//+kubebuilder:validation:Optional
 	LogHostPath string `json:"logHostPath,omitempty"`
 }

--- a/config/crd/bases/csi.ceph.io_drivers.yaml
+++ b/config/crd/bases/csi.ceph.io_drivers.yaml
@@ -3542,11 +3542,14 @@ spec:
                     description: log rotation for csi pods
                     properties:
                       logHostPath:
-                        description: LogHostPath is the prefix directory path for
-                          the csi log files
+                        description: |-
+                          LogHostPath is the prefix directory path for the csi log files
+                          Default to /var/lib/cephcsi
                         type: string
                       maxFiles:
-                        description: MaxFiles is the number of logrtoate files
+                        description: |-
+                          MaxFiles is the number of logrtoate files
+                          Default to 7
                         type: integer
                       maxLogSize:
                         anyOf:
@@ -3565,6 +3568,9 @@ spec:
                         - monthly
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: Either maxLogSize or periodicity must be set
+                      rule: (has(self.maxLogSize)) || (has(self.periodicity))
                   verbosity:
                     description: |-
                       Log verbosity level for driver pods,

--- a/config/crd/bases/csi.ceph.io_operatorconfigs.yaml
+++ b/config/crd/bases/csi.ceph.io_operatorconfigs.yaml
@@ -3581,11 +3581,14 @@ spec:
                         description: log rotation for csi pods
                         properties:
                           logHostPath:
-                            description: LogHostPath is the prefix directory path
-                              for the csi log files
+                            description: |-
+                              LogHostPath is the prefix directory path for the csi log files
+                              Default to /var/lib/cephcsi
                             type: string
                           maxFiles:
-                            description: MaxFiles is the number of logrtoate files
+                            description: |-
+                              MaxFiles is the number of logrtoate files
+                              Default to 7
                             type: integer
                           maxLogSize:
                             anyOf:
@@ -3605,6 +3608,9 @@ spec:
                             - monthly
                             type: string
                         type: object
+                        x-kubernetes-validations:
+                        - message: Either maxLogSize or periodicity must be set
+                          rule: (has(self.maxLogSize)) || (has(self.periodicity))
                       verbosity:
                         description: |-
                           Log verbosity level for driver pods,

--- a/docs/design/logrotate.md
+++ b/docs/design/logrotate.md
@@ -13,14 +13,14 @@ apiVersion: csi.ceph.io/v1alpha1
 spec: 
     log:
         verbosity: 1 
-    driverSpecDefaults: 
+    driverSpecDefaults:
         log:
             verbosity: 5
             rotation:
                 # one of: hourly, daily, weekly, monthly
                 periodicity: daily
                 maxLogSize: 500M 
-                maxFiles: 5
+                maxFiles: 7
                 logHostPath: /var/lib/cephcsi 
 ```
 
@@ -35,14 +35,14 @@ metadata:
 spec: 
     log:
         verbosity: 1 
-    driverSpecDefaults: 
+    driverSpecDefaults:
         log: 
             verbosity: 5
             rotation:
                  # one of: hourly, daily, weekly, monthly
                 periodicity: daily
                 maxLogSize: 500M 
-                maxFiles: 5
+                maxFiles: 7
                 logHostPath: /var/lib/cephcsi 
 ```
 
@@ -51,20 +51,24 @@ Logrotator sidecar container cpu and memory usage can configured by,
 `OperatorConfig CRD`:
 ```yaml
 spec:
-    provisioner:
-        logRotator:
-            cpu: "100m"
-            memory: "32Mi"
-    plugin:
-        logRotator:
-            cpu: "100m"
-            memory: "32Mi"         
+    driverSpecDefaults:
+        controllerPlugin:
+            resources:
+                logRotator:
+                    cpu: "100m"
+                    memory: "32Mi"
+        nodePlugin:
+            resources:
+                logRotator:
+                    cpu: "100m"
+                    memory: "32Mi"                          
 ```
 
-For systems where SELinux is enabled (e.g. OpenShift),start plugin-controller as privileged that mount a host path.
+For systems where SELinux is enabled (e.g. OpenShift), start plugin-controller as privileged that mount a host path.
 `OperatorConfig CRD`:
 ```yaml
 spec:
-    provisioner:
-        privileged: true
+    driverSpecDefaults:
+        controllerPlugin:
+            privileged: true
 ```

--- a/docs/design/operator.md
+++ b/docs/design/operator.md
@@ -92,7 +92,7 @@ spec:
         # one of: hourly, daily, weekly, monthly
         periodicity: daily
         maxLogSize: 500M 
-        maxFiles: 5
+        maxFiles: 7
         logHostPath: /var/lib/cephcsi 
     clusterName: 5c63ad7e-74fe-4724-a511-4ccdc560da56
     enableMetadata: true

--- a/internal/controller/defaults.go
+++ b/internal/controller/defaults.go
@@ -38,8 +38,10 @@ var imageDefaults = map[string]string{
 }
 
 const (
-	defaultGRrpcTimeout   = 150
-	defaultKubeletDirPath = "/var/lib/kubelet"
+	defaultGRrpcTimeout      = 150
+	defaultKubeletDirPath    = "/var/lib/kubelet"
+	defaultLogHostPath       = "/var/lib/cephcsi"
+	defaultLogRotateMaxFiles = 7
 )
 
 var defaultLeaderElection = csiv1a1.LeaderElectionSpec{


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi-operator! -->

# Describe what this PR does #

1) Make main container and csi addons container
   log to a file(dependency on klog)

2) Add a log-rotate sidecar container,
   so it can rotate the logs

3) Added other volume and volumemounts as needed

4) Added the privileged option for controllerplugin


Provide some context for the reviewer

## Is there anything that requires special attention ##

Do you have any questions?

Is the change backward compatible?

Are there concerns around backward compatibility?

Provide any external context for the change, if any.

For example:

* Kubernetes links that explain why the change is required
* Ceph-CSI spec related changes/catch-up that necessitates this patch
* golang related practices that necessitates this change

## Related issues ##

Mention any github issues relevant to this PR. Adding below line
will help to auto close the issue once the PR is merged.

Fixes: #issue_number

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi-operator/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi-operator/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi-operator/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.
