### PR TITLE
Use list of BlockPoolMapping in clientProfileMappings spec

### DIFF
--- a/api/v1alpha1/clientprofilemapping_types.go
+++ b/api/v1alpha1/clientprofilemapping_types.go
@@ -42,7 +42,7 @@ type BlockPoolMappingSpec struct {
 // ClientProfileMappingSpec defines the desired state of ClientProfileMapping
 type ClientProfileMappingSpec struct {
 	//+kubebuilder:validation:Optional
-	BlockPoolMapping *BlockPoolMappingSpec `json:"blockPoolMapping,omitempty"`
+	BlockPoolMapping []BlockPoolMappingSpec `json:"blockPoolMapping,omitempty"`
 }
 
 // ClientProfileMappingStatus defines the observed state of ClientProfileMapping

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -305,8 +305,8 @@ func (in *ClientProfileMappingSpec) DeepCopyInto(out *ClientProfileMappingSpec) 
 	*out = *in
 	if in.BlockPoolMapping != nil {
 		in, out := &in.BlockPoolMapping, &out.BlockPoolMapping
-		*out = new(BlockPoolMappingSpec)
-		**out = **in
+		*out = make([]BlockPoolMappingSpec, len(*in))
+		copy(*out, *in)
 	}
 }
 

--- a/config/crd/bases/csi.ceph.io_clientprofilemappings.yaml
+++ b/config/crd/bases/csi.ceph.io_clientprofilemappings.yaml
@@ -41,30 +41,32 @@ spec:
             description: ClientProfileMappingSpec defines the desired state of ClientProfileMapping
             properties:
               blockPoolMapping:
-                description: BlockPoolMappingSpec define a mapiing between a local
-                  and remote block pools
-                properties:
-                  local:
-                    description: BlockPoolRefSpec identify a blockpool - client profile
-                      pair
-                    properties:
-                      clientProfileName:
-                        type: string
-                      poolId:
-                        minimum: 0
-                        type: integer
-                    type: object
-                  remote:
-                    description: BlockPoolRefSpec identify a blockpool - client profile
-                      pair
-                    properties:
-                      clientProfileName:
-                        type: string
-                      poolId:
-                        minimum: 0
-                        type: integer
-                    type: object
-                type: object
+                items:
+                  description: BlockPoolMappingSpec define a mapiing between a local
+                    and remote block pools
+                  properties:
+                    local:
+                      description: BlockPoolRefSpec identify a blockpool - client
+                        profile pair
+                      properties:
+                        clientProfileName:
+                          type: string
+                        poolId:
+                          minimum: 0
+                          type: integer
+                      type: object
+                    remote:
+                      description: BlockPoolRefSpec identify a blockpool - client
+                        profile pair
+                      properties:
+                        clientProfileName:
+                          type: string
+                        poolId:
+                          minimum: 0
+                          type: integer
+                      type: object
+                  type: object
+                type: array
             type: object
           status:
             description: ClientProfileMappingStatus defines the observed state of


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi-operator! -->

# Describe what this PR does #
Changes BlockPoolMappings spec to list in the API

Provide some context for the reviewer

## Is there anything that requires special attention ##

Do you have any questions?

Is the change backward compatible?

Are there concerns around backward compatibility?

Provide any external context for the change, if any.

For example:

* Kubernetes links that explain why the change is required
* Ceph-CSI spec related changes/catch-up that necessitates this patch
* golang related practices that necessitates this change

## Related issues ##

Mention any github issues relevant to this PR. Adding below line
will help to auto close the issue once the PR is merged.

Fixes: #issue_number

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi-operator/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi-operator/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi-operator/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.
