### PR TITLE
ci: fix problem in build-push action

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -24,12 +24,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-        #- name: Login to Quay.io
-        #uses: docker/login-action@v3
-        #with:
-        #  registry: quay.io
-        #  username: ${{ secrets.QUAY_IO_USERNAME }}
-        #  password: ${{ secrets.QUAY_IO_PASSWORD }}
+      - name: Login to Quay.io
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_IO_USERNAME }}
+          password: ${{ secrets.QUAY_IO_PASSWORD }}
       - name: Set up Image tag
         run: |
           echo "image tag ${{ github.ref }}"
@@ -42,8 +42,6 @@ jobs:
             TAG=$(echo ${{ github.ref }} | sed 's/refs\/tags\///')
             echo "IMAGE_TAG=${TAG}" >> $GITHUB_ENV
           fi
-      - name: print env
-        run: echo $IMAGE_TAG
 
       - name: Build and push Docker images
         run: make docker-buildx IMAGE_TAG=${{ env.IMAGE_TAG }}


### PR DESCRIPTION
Remove commented out quay login which is required to push the image and also remove the step to print env.

