### PR TITLE
add name length validation for driver

### DIFF
--- a/api/v1alpha1/driver_types.go
+++ b/api/v1alpha1/driver_types.go
@@ -371,6 +371,7 @@ type DriverStatus struct {
 //+kubebuilder:subresource:status
 
 // +kubebuilder:validation:XValidation:rule=self.metadata.name.matches('^(.+\\.)?(rbd|cephfs|nfs)?\\.csi\\.ceph\\.com$'),message=".metadata.name must match: '[<prefix>.](rbd|cephfs|nfs).csi.ceph.com'"
+// +kubebuilder:validation:XValidation:rule="self.metadata.name.size() <= 54",message=".metadata.name must be no more than 54 characters"
 // Driver is the Schema for the drivers API
 type Driver struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/config/crd/bases/csi.ceph.io_drivers.yaml
+++ b/config/crd/bases/csi.ceph.io_drivers.yaml
@@ -6788,6 +6788,8 @@ spec:
         x-kubernetes-validations:
         - message: '.metadata.name must match: ''[<prefix>.](rbd|cephfs|nfs).csi.ceph.com'''
           rule: self.metadata.name.matches('^(.+\\.)?(rbd|cephfs|nfs)?\\.csi\\.ceph\\.com$')
+        - message: .metadata.name must be no more than 54 characters
+          rule: self.metadata.name.size() <= 54
     served: true
     storage: true
     subresources:


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi-operator! -->

# Describe what this PR does #

Choosing an arbitrary length which is 56 for the csi driver name and adding a validation to block CR creation i the name has more chars.

## Is there anything that requires special attention ##

Do you have any questions?

No

Is the change backward compatible?

Yes but only to an extent

Are there concerns around backward compatibility?

Yes, the migration not be possible for the existing driver if names are beyond 63 chars, or else we don't have a problem.


## Related issues ##

Fixes: #44 

