### PR TITLE
Driver Controller: Ensure CSI Config Creation

### DIFF
--- a/internal/controller/clientprofile_controller.go
+++ b/internal/controller/clientprofile_controller.go
@@ -213,8 +213,8 @@ func (r *ClientProfileReconcile) reconcileCephConnection() error {
 
 	if needsUpdate, err := utils.ToggleOwnerReference(
 		!r.cleanUp,
-		&r.clientProfile,
 		&r.cephConn,
+		&r.clientProfile,
 		r.Scheme,
 	); err != nil {
 		r.log.Error(err, "Failed to toggle owner reference on CephConnection")
@@ -249,8 +249,8 @@ func (r *ClientProfileReconcile) reconcileCephCsiClusterInfo() error {
 	_, err := ctrlutil.CreateOrUpdate(r.ctx, r.Client, &csiConfigMap, func() error {
 		if _, err := utils.ToggleOwnerReference(
 			!r.cleanUp,
-			&r.clientProfile,
 			&csiConfigMap,
+			&r.clientProfile,
 			r.Scheme,
 		); err != nil {
 			log.Error(err, "Failed toggling owner reference for Ceph CSI config map")

--- a/internal/utils/meta.go
+++ b/internal/utils/meta.go
@@ -51,19 +51,14 @@ func IsOwnedBy(obj, owner metav1.Object) bool {
 // The function return true if the owner reference list had changed and false it it didn't
 func ToggleOwnerReference(on bool, obj, owner metav1.Object, scheme *runtime.Scheme) (bool, error) {
 	ownerRefExists := IsOwnedBy(obj, owner)
-
 	if on {
 		if !ownerRefExists {
-			if err := ctrlutil.SetOwnerReference(obj, owner, scheme); err != nil {
-				return false, err
-			}
-			return true, nil
+			err := ctrlutil.SetOwnerReference(owner, obj, scheme)
+			return err == nil, err
 		}
 	} else if ownerRefExists {
-		if err := ctrlutil.RemoveOwnerReference(obj, owner, scheme); err != nil {
-			return false, err
-		}
-		return true, nil
+		err := ctrlutil.RemoveOwnerReference(owner, obj, scheme)
+		return err == nil, err
 	}
 	return false, nil
 }

--- a/internal/utils/predicates.go
+++ b/internal/utils/predicates.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// Name Predicate return a predicate the filter events produced
+// by resources that matches the given name
+func NamePredicate(name string) predicate.Predicate {
+	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		return obj.GetName() == name
+	})
+}
+
+// EventTypePredicate return a predicate the filter events based on their
+// respective event type. This helper allows for the selection of multiple
+// types resulting in a predicate that can filter in more then a single event
+// type
+func EventTypePredicate(create, update, del, generic bool) predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(_ event.CreateEvent) bool {
+			return create
+		},
+		UpdateFunc: func(_ event.UpdateEvent) bool {
+			return update
+		},
+		DeleteFunc: func(_ event.DeleteEvent) bool {
+			return del
+		},
+		GenericFunc: func(_ event.GenericEvent) bool {
+			return generic
+		},
+	}
+}


### PR DESCRIPTION
# Describe what this PR does #

If a driver CR exists but no client profile CR exists, any container that needs to mount the `ceph-csi-config` config map will fail. To solve the issue, the following behavior is added:

- Driver controller creates an empty `ceph-csi-config` config map if not already exist and adds an owner ref
- Driver controller watch for delete events for `ceph-csi-config` config map 

