### PR TITLE
run csiaddons sidecar only for rbd nodeplugin

### DIFF
--- a/internal/controller/driver_controller.go
+++ b/internal/controller/driver_controller.go
@@ -649,7 +649,7 @@ func (r *driverReconcile) reconcileControllerPluginDeployment() error {
 							})
 						}
 						// Addons Sidecar Container
-						if ptr.Deref(r.driver.Spec.DeployCsiAddons, false) {
+						if !r.isNfsDriver() && ptr.Deref(r.driver.Spec.DeployCsiAddons, false) {
 							containers = append(containers, corev1.Container{
 								Name:            "csi-addons",
 								Image:           r.images["addons"],
@@ -951,7 +951,7 @@ func (r *driverReconcile) reconcileNodePluginDeamonSet() error {
 							},
 						}
 						// CSI Addons Sidecar Container
-						if ptr.Deref(r.driver.Spec.DeployCsiAddons, false) {
+						if r.isRdbDriver() && ptr.Deref(r.driver.Spec.DeployCsiAddons, false) {
 							containers = append(containers, corev1.Container{
 								Name:            "csi-addons",
 								Image:           r.images["addons"],


### PR DESCRIPTION
run csiaddons sidecar only for rbd nodeplugin its not required for cephfs/nfs and also don't run csi-addons for nfs deployment

