### PR TITLE
ClientProfile Controller: add missing CephConnection delete RBAC

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -57,6 +57,7 @@ rules:
   resources:
   - cephconnections
   verbs:
+  - delete
   - get
   - list
   - update

--- a/internal/controller/clientprofile_controller.go
+++ b/internal/controller/clientprofile_controller.go
@@ -40,7 +40,7 @@ import (
 //+kubebuilder:rbac:groups=csi.ceph.io,resources=clientprofiles,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=csi.ceph.io,resources=clientprofiles/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=csi.ceph.io,resources=clientprofiles/finalizers,verbs=update
-//+kubebuilder:rbac:groups=csi.ceph.io,resources=cephconnections,verbs=get;list;watch;update
+//+kubebuilder:rbac:groups=csi.ceph.io,resources=cephconnections,verbs=get;list;watch;update;delete
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 
 // ClientProfileReconciler reconciles a ClientProfile object


### PR DESCRIPTION
# Describe what this PR does #

Adds missing CephConnection delete RBAC
Delete RBAC is needed in order to enable us to add an owner reference w

## Is there anything that requires special attention ##

no