### PR TITLE
Configuration: Kustomisation enhancements

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,13 +1,3 @@
-# Adds namespace to all resources.
-namespace: ceph-csi-operator-system
-
-# Value of this field is prepended to the
-# names of all resources, e.g. a deployment named
-# "wordpress" becomes "alices-wordpress".
-# Note that it should also match with the prefix (text before '-') of the namespace
-# field above.
-namePrefix: ceph-csi-operator-
-
 # Labels to add to all resources and selectors.
 #labels:
 #- includeSelectors: true

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -2,7 +2,3 @@ resources:
 - manager.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-images:
-- name: controller
-  newName: quay.io/cephcsi/ceph-csi-operator
-  newTag: latest

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -62,7 +62,7 @@ spec:
         - /manager
         args:
         - --leader-elect
-        image: controller:latest
+        image: controller
         name: manager
         securityContext:
           allowPrivilegeEscalation: false

--- a/internal/controller/defaults.go
+++ b/internal/controller/defaults.go
@@ -73,3 +73,7 @@ var operatorConfigName = utils.Call(func() string {
 	}
 	return "ceph-csi-operator-config"
 })
+
+var serviceAccountPrefix = utils.Call(func() string {
+	return os.Getenv("CSI_SERVICE_ACCOUNT_PREFIX")
+})

--- a/internal/controller/driver_controller.go
+++ b/internal/controller/driver_controller.go
@@ -447,7 +447,7 @@ func (r *driverReconcile) reconcileControllerPluginDeployment() error {
 		pluginSpec := cmp.Or(r.driver.Spec.ControllerPlugin, &csiv1a1.ControllerPluginSpec{})
 		serviceAccountName := cmp.Or(
 			ptr.Deref(pluginSpec.ServiceAccountName, ""),
-			fmt.Sprintf("csi-%s-ctrlplugin-sa", r.driverType),
+			fmt.Sprintf("%s%s-ctrlplugin-sa", serviceAccountPrefix, r.driverType),
 		)
 		imagePullPolicy := cmp.Or(pluginSpec.ImagePullPolicy, corev1.PullIfNotPresent)
 		grpcTimeout := cmp.Or(r.driver.Spec.GRpcTimeout, defaultGRrpcTimeout)
@@ -798,7 +798,7 @@ func (r *driverReconcile) reconcileNodePluginDeamonSet() error {
 		pluginSpec := cmp.Or(r.driver.Spec.NodePlugin, &csiv1a1.NodePluginSpec{})
 		serviceAccountName := cmp.Or(
 			ptr.Deref(pluginSpec.ServiceAccountName, ""),
-			fmt.Sprintf("csi-%s-nodeplugin-sa", r.driverType),
+			fmt.Sprintf("%s%s-nodeplugin-sa", serviceAccountPrefix, r.driverType),
 		)
 		imagePullPolicy := cmp.Or(pluginSpec.ImagePullPolicy, corev1.PullIfNotPresent)
 		logVerbosity := ptr.Deref(r.driver.Spec.Log, csiv1a1.LogSpec{}).Verbosity


### PR DESCRIPTION
# Describe what this PR does #

- Make commands that use kustomize no longer edit the local config folder and have zero side effects on local repo files
- Driver controller now accepts a service account prefix from an env var injected into the deployment via kustomize
- Enable setting of env vars before `build-installer`, `build-csi-rbac`, and `deploy` make target to allow kustomization. Example:

```NAME_PREFIX=\<prefix\> NAMESPACE=\<target_namspace\> make deploy``

This change also ensures that both `build-installer` and `deploy` create
RBAC, CSI RBAC, and SA accounts that allow the operator to run without
any need for manual changes!

