### PR TITLE
Add readOnlyRootFilesystem and remove logtostderr

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -12,6 +12,7 @@ spec:
       - name: kube-rbac-proxy
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
           capabilities:
             drop:
             - "ALL"

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -20,7 +20,6 @@ spec:
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"
-        - "--logtostderr=true"
         - "--v=0"
         ports:
         - containerPort: 8443

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -66,6 +66,7 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
           capabilities:
             drop:
             - "ALL"


### PR DESCRIPTION
This PR is adding readOnlyRootFilesystem for both containers (manager and kube-proxy) as per security standards and remove deprecated logtostderr from kube-proxy container arg