### PR TITLE
update api description to be inline with the expected behaviour

### DIFF
--- a/api/v1alpha1/driver_types.go
+++ b/api/v1alpha1/driver_types.go
@@ -302,8 +302,8 @@ type DriverSpec struct {
 
 	// OMAP generator will generate the omap mapping between the PV name and the RBD image.
 	// Need to be enabled when we are using rbd mirroring feature.
-	// By default OMAP generator sidecar is deployed with Csi controller plugin pod, to disable
-	// it set it to false.
+	// By default OMAP generator sidecar is not deployed with Csi controller plugin pod, to enable
+	// it set it to true.
 	//+kubebuilder:validation:Optional
 	GenerateOMapInfo *bool `json:"generateOMapInfo,omitempty"`
 

--- a/config/crd/bases/csi.ceph.io_drivers.yaml
+++ b/config/crd/bases/csi.ceph.io_drivers.yaml
@@ -3466,8 +3466,8 @@ spec:
                 description: |-
                   OMAP generator will generate the omap mapping between the PV name and the RBD image.
                   Need to be enabled when we are using rbd mirroring feature.
-                  By default OMAP generator sidecar is deployed with Csi controller plugin pod, to disable
-                  it set it to false.
+                  By default OMAP generator sidecar is not deployed with Csi controller plugin pod, to enable
+                  it set it to true.
                 type: boolean
               grpcTimeout:
                 description: Set the gRPC timeout for gRPC call issued by the driver

--- a/config/crd/bases/csi.ceph.io_operatorconfigs.yaml
+++ b/config/crd/bases/csi.ceph.io_operatorconfigs.yaml
@@ -3505,8 +3505,8 @@ spec:
                     description: |-
                       OMAP generator will generate the omap mapping between the PV name and the RBD image.
                       Need to be enabled when we are using rbd mirroring feature.
-                      By default OMAP generator sidecar is deployed with Csi controller plugin pod, to disable
-                      it set it to false.
+                      By default OMAP generator sidecar is not deployed with Csi controller plugin pod, to enable
+                      it set it to true.
                     type: boolean
                   grpcTimeout:
                     description: Set the gRPC timeout for gRPC call issued by the

--- a/deploy/all-in-one/install.yaml
+++ b/deploy/all-in-one/install.yaml
@@ -3716,8 +3716,8 @@ spec:
                 description: |-
                   OMAP generator will generate the omap mapping between the PV name and the RBD image.
                   Need to be enabled when we are using rbd mirroring feature.
-                  By default OMAP generator sidecar is deployed with Csi controller plugin pod, to disable
-                  it set it to false.
+                  By default OMAP generator sidecar is not deployed with Csi controller plugin pod, to enable
+                  it set it to true.
                 type: boolean
               grpcTimeout:
                 description: Set the gRPC timeout for gRPC call issued by the driver
@@ -10554,8 +10554,8 @@ spec:
                     description: |-
                       OMAP generator will generate the omap mapping between the PV name and the RBD image.
                       Need to be enabled when we are using rbd mirroring feature.
-                      By default OMAP generator sidecar is deployed with Csi controller plugin pod, to disable
-                      it set it to false.
+                      By default OMAP generator sidecar is not deployed with Csi controller plugin pod, to enable
+                      it set it to true.
                     type: boolean
                   grpcTimeout:
                     description: Set the gRPC timeout for gRPC call issued by the

--- a/deploy/multifile/crd.yaml
+++ b/deploy/multifile/crd.yaml
@@ -3707,8 +3707,8 @@ spec:
                 description: |-
                   OMAP generator will generate the omap mapping between the PV name and the RBD image.
                   Need to be enabled when we are using rbd mirroring feature.
-                  By default OMAP generator sidecar is deployed with Csi controller plugin pod, to disable
-                  it set it to false.
+                  By default OMAP generator sidecar is not deployed with Csi controller plugin pod, to enable
+                  it set it to true.
                 type: boolean
               grpcTimeout:
                 description: Set the gRPC timeout for gRPC call issued by the driver
@@ -10545,8 +10545,8 @@ spec:
                     description: |-
                       OMAP generator will generate the omap mapping between the PV name and the RBD image.
                       Need to be enabled when we are using rbd mirroring feature.
-                      By default OMAP generator sidecar is deployed with Csi controller plugin pod, to disable
-                      it set it to false.
+                      By default OMAP generator sidecar is not deployed with Csi controller plugin pod, to enable
+                      it set it to true.
                     type: boolean
                   grpcTimeout:
                     description: Set the gRPC timeout for gRPC call issued by the


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi-operator! -->

# Describe what this PR does #

The omap generator is not deployed by default but the API states that it is. update the API description to the expected behaviour

## Related issues ##

Fixes: https://github.com/ceph/ceph-csi-operator/issues/131

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi-operator/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi-operator/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi-operator/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [x] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.
