### PR TITLE
Makefile: fix panic in make test.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ build: manifests generate fmt vet ## Build manager binary.
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
-	go run ./cmd/main.go
+	OPERATOR_NAMESPACE="$(shell echo $${OPERATOR_NAMESPACE:=$(NAMESPACE)})" go run ./cmd/main.go
 
 # If you wish to build the manager image targeting other platforms you can use the --platform flag.
 # (i.e. docker build --platform linux/arm64). However, you must enable docker buildKit for it.

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
+	OPERATOR_NAMESPACE="$(shell echo $${OPERATOR_NAMESPACE:=$(NAMESPACE)})" KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
 
 # Utilize Kind or modify the e2e tests to load the image locally, enabling compatibility with other vendors.
 .PHONY: test-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.


### PR DESCRIPTION
# Describe what this PR does #


This stops `make test` from failing with a panic of  the operator by making sure OPERATOR_NAMESPACE is set in the shell environment.

It does not fix make test completely though  but lets it at least pass the first obstacle.





Provide some context for the reviewer

## Is there anything that requires special attention ##

Do you have any questions? - no.

Is the change backward compatible? - should be.

Are there concerns around backward compatibility? - no.


## Related issues ##

Mention any github issues relevant to this PR. Adding below line
will help to auto close the issue once the PR is merged.

Resolves: #133 

## Future concerns ##

* `make test` is still failing. this should be fixed
* `make test`is not currently run in the CI. It should be.
* 



**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi-operator/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi-operator/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi-operator/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.
