### PR TITLE
Makefile: Simplify 'test' and 'run' targets a bit.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	OPERATOR_NAMESPACE="$(shell echo $${OPERATOR_NAMESPACE:=$(NAMESPACE)})" KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
+	OPERATOR_NAMESPACE="$${OPERATOR_NAMESPACE:=$(NAMESPACE)}" KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
 
 # Utilize Kind or modify the e2e tests to load the image locally, enabling compatibility with other vendors.
 .PHONY: test-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.
@@ -134,7 +134,7 @@ build: manifests generate fmt vet ## Build manager binary.
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
-	OPERATOR_NAMESPACE="$(shell echo $${OPERATOR_NAMESPACE:=$(NAMESPACE)})" go run ./cmd/main.go
+	OPERATOR_NAMESPACE="$${OPERATOR_NAMESPACE:=$(NAMESPACE)}" go run ./cmd/main.go
 
 # If you wish to build the manager image targeting other platforms you can use the --platform flag.
 # (i.e. docker build --platform linux/arm64). However, you must enable docker buildKit for it.


### PR DESCRIPTION
This follows a recommendation on a previous PR:

https://github.com/ceph/ceph-csi-operator/pull/134#discussion_r1761416232





# Describe what this PR does #

This change  simplifies the code to  conditionally set  shell variables in the make targets `run` and `test` that was introduced in #134


Provide some context for the reviewer

No change in behavior is introduced, just a cleanup of the implementation that should make no difference to the user.



## Is there anything that requires special attention ##

Do you have any questions?

no.

Is the change backward compatible?

should be.


Are there concerns around backward compatibility?

no.

Provide any external context for the change, if any.

none



## Related issues ##


none, but see https://github.com/ceph/ceph-csi-operator/pull/134#discussion_r1761416232


## Future concerns ##

no future concerns.

**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi-operator/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi-operator/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi-operator/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.
