### PR TITLE
add missing rbac for persistentvolume during deletion

### DIFF
--- a/config/csi-rbac/cephfs_ctrlplugin_cluster_role.yaml
+++ b/config/csi-rbac/cephfs_ctrlplugin_cluster_role.yaml
@@ -8,7 +8,7 @@ rules:
     verbs: ["get", "list"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch", "create", "delete", "patch"]
+    verbs: ["get", "list", "watch", "create", "delete", "patch", "update"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
     verbs: ["get", "list", "watch", "patch", "update"]

--- a/config/csi-rbac/rbd_ctrlplugin_cluster_role.yaml
+++ b/config/csi-rbac/rbd_ctrlplugin_cluster_role.yaml
@@ -8,7 +8,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch", "create", "delete", "patch"]
+    verbs: ["get", "list", "watch", "create", "delete", "patch", "update"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
     verbs: ["get", "list", "watch", "update"]

--- a/deploy/all-in-one/install.yaml
+++ b/deploy/all-in-one/install.yaml
@@ -14146,6 +14146,7 @@ rules:
   - create
   - delete
   - patch
+  - update
 - apiGroups:
   - ""
   resources:
@@ -14829,6 +14830,7 @@ rules:
   - create
   - delete
   - patch
+  - update
 - apiGroups:
   - ""
   resources:

--- a/deploy/multifile/csi-rbac.yaml
+++ b/deploy/multifile/csi-rbac.yaml
@@ -118,6 +118,7 @@ rules:
   - create
   - delete
   - patch
+  - update
 - apiGroups:
   - ""
   resources:
@@ -405,6 +406,7 @@ rules:
   - create
   - delete
   - patch
+  - update
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
Fixes 
```
W0918 10:12:09.506345       1 controller.go:989] Retrying syncing volume "pvc-1de9079b-1287-4d36-8998-db0a264b7488", failure 1                                                
E0918 10:12:09.506382       1 controller.go:1007] error syncing volume "pvc-1de9079b-1287-4d36-8998-db0a264b7488": persistentvolumes "pvc-1de9079b-1287-4d36-8998-db0a264b7488
" is forbidden: User "system:serviceaccount:openshift-storage-client:ceph-csi-rbd-ctrlplugin-sa" cannot update resource "persistentvolumes" in API group "" at the cluster sco
pe                                                                                                                                                                            
I0918 10:12:09.705796       1 controller.go:1561] delete "pvc-008acf6c-eba1-41f4-bffd-2a0a70d37081": failed to remove finalizer for persistentvolume: persistentvolumes "pvc-0
08acf6c-eba1-41f4-bffd-2a0a70d37081" is forbidden: User "system:serviceaccount:openshift-storage-client:ceph-csi-rbd-ctrlplugin-sa" cannot update resource "persistentvolumes"
 in API group "" at the cluster scope  
```

RC as per @Madhu-1 some version of csi sidecar requires `pv/patch` and another version requires `pv/update` rbac.