### PR TITLE
do not always error out while checking for existence of resources

### DIFF
--- a/internal/controller/clientprofile_controller.go
+++ b/internal/controller/clientprofile_controller.go
@@ -130,6 +130,10 @@ func (r *ClientProfileReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 func (r *ClientProfileReconcile) reconcile() error {
 	if err := r.loadAndValidate(); err != nil {
+		if utils.IsNotFoundWithName(err, r.clientProfile.Name) {
+			r.log.Info("Client profile resource does not exists anymore, skipping reconcile")
+			return nil
+		}
 		return err
 	}
 

--- a/internal/controller/driver_controller.go
+++ b/internal/controller/driver_controller.go
@@ -226,6 +226,10 @@ func (r *DriverReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 func (r *driverReconcile) reconcile() error {
 	// Load the driver desired state based on driver resource, operator config resource and default values.
 	if err := r.LoadAndValidateDesiredState(); err != nil {
+		if utils.IsNotFoundWithName(err, r.driver.Name) {
+			r.log.Info("Driver resource does not exist anymore, skipping reconcile")
+			return nil
+		}
 		return err
 	}
 

--- a/internal/utils/meta.go
+++ b/internal/utils/meta.go
@@ -17,6 +17,9 @@ limitations under the License.
 package utils
 
 import (
+	"errors"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -61,4 +64,14 @@ func ToggleOwnerReference(on bool, obj, owner metav1.Object, scheme *runtime.Sch
 		return err == nil, err
 	}
 	return false, nil
+}
+
+func IsNotFoundWithName(err error, name string) bool {
+	if !k8serrors.IsNotFound(err) {
+		return false
+	}
+	status, ok := err.(k8serrors.APIStatus)
+	return (ok || errors.As(err, &status)) &&
+		status.Status().Details != nil &&
+		status.Status().Details.Name == name
 }


### PR DESCRIPTION
controllers also get reconciles for deletion events and it may happen that resource at api server be deleted first before it being purged from cache and during that time if we error out the reconciliation will never be successful in standard conditions.

fixes: #78