### PR TITLE
remove extra deep copy of object from cache

### DIFF
--- a/internal/controller/driver_controller.go
+++ b/internal/controller/driver_controller.go
@@ -312,9 +312,6 @@ func (r *driverReconcile) LoadAndValidateDesiredState() error {
 	r.images = maps.Clone(imageDefaults)
 
 	if opConfig.Spec.DriverSpecDefaults != nil {
-		// Creating a copy of the driver spec, making sure any local changes will not effect the object residing
-		// in the client's cache
-		r.driver.Spec = *r.driver.Spec.DeepCopy()
 		mergeDriverSpecs(&r.driver.Spec, opConfig.Spec.DriverSpecDefaults)
 
 		// If provided, load an imageset from configmap to overwrite default images


### PR DESCRIPTION
controller-runtime accepts the pointer to the memory which is reserved by application and runtime deepcopies the object in it's cache to the memory provided by application.

this commit removes extra copy of driver spec which isn't required.

fixes: #58