### PR TITLE
provide ability to adjust deployment strategy

### DIFF
--- a/api/v1alpha1/driver_types.go
+++ b/api/v1alpha1/driver_types.go
@@ -213,6 +213,11 @@ type ControllerPluginSpec struct {
 	// Embedded common pods spec
 	PodCommonSpec `json:",inline"`
 
+	// DeploymentStrategy describes how to replace existing pods with new ones
+	// Default value is RollingUpdate with MaxUnavailable and MaxSurege as 25% (kubernetes default)
+	//+kubebuilder:validation:Optional
+	DeploymentStrategy *appsv1.DeploymentStrategy `json:"deploymentStrategy,omitempty"`
+
 	// Set replicas for controller plugin's deployment. Defaults to 2
 	//+kubebuilder:validation:Optional
 	//+kubebuilder:validation:Minimum:=1

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -438,6 +438,11 @@ func (in *ControllerPluginResourcesSpec) DeepCopy() *ControllerPluginResourcesSp
 func (in *ControllerPluginSpec) DeepCopyInto(out *ControllerPluginSpec) {
 	*out = *in
 	in.PodCommonSpec.DeepCopyInto(&out.PodCommonSpec)
+	if in.DeploymentStrategy != nil {
+		in, out := &in.DeploymentStrategy, &out.DeploymentStrategy
+		*out = new(appsv1.DeploymentStrategy)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Replicas != nil {
 		in, out := &in.Replicas, &out.Replicas
 		*out = new(int32)

--- a/config/crd/bases/csi.ceph.io_drivers.yaml
+++ b/config/crd/bases/csi.ceph.io_drivers.yaml
@@ -999,6 +999,58 @@ spec:
                       type: string
                     description: Pod's annotations
                     type: object
+                  deploymentStrategy:
+                    description: |-
+                      DeploymentStrategy describes how to replace existing pods with new ones
+                      Default value is RollingUpdate with MaxUnavailable and MaxSurege as 25% (kubernetes default)
+                    properties:
+                      rollingUpdate:
+                        description: |-
+                          Rolling update config params. Present only if DeploymentStrategyType =
+                          RollingUpdate.
+                          ---
+                          TODO: Update this to follow our convention for oneOf, whatever we decide it
+                          to be.
+                        properties:
+                          maxSurge:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              The maximum number of pods that can be scheduled above the desired number of
+                              pods.
+                              Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                              This can not be 0 if MaxUnavailable is 0.
+                              Absolute number is calculated from percentage by rounding up.
+                              Defaults to 25%.
+                              Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when
+                              the rolling update starts, such that the total number of old and new pods do not exceed
+                              130% of desired pods. Once old pods have been killed,
+                              new ReplicaSet can be scaled up further, ensuring that total number of pods running
+                              at any time during the update is at most 130% of desired pods.
+                            x-kubernetes-int-or-string: true
+                          maxUnavailable:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              The maximum number of pods that can be unavailable during the update.
+                              Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                              Absolute number is calculated from percentage by rounding down.
+                              This can not be 0 if MaxSurge is 0.
+                              Defaults to 25%.
+                              Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods
+                              immediately when the rolling update starts. Once new pods are ready, old ReplicaSet
+                              can be scaled down further, followed by scaling up the new ReplicaSet, ensuring
+                              that the total number of pods available at all times during the update is at
+                              least 70% of desired pods.
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      type:
+                        description: Type of deployment. Can be "Recreate" or "RollingUpdate".
+                          Default is RollingUpdate.
+                        type: string
+                    type: object
                   imagePullPolicy:
                     description: To indicate the image pull policy to be applied to
                       all the containers in the csi driver pods.

--- a/config/crd/bases/csi.ceph.io_operatorconfigs.yaml
+++ b/config/crd/bases/csi.ceph.io_operatorconfigs.yaml
@@ -1008,6 +1008,58 @@ spec:
                           type: string
                         description: Pod's annotations
                         type: object
+                      deploymentStrategy:
+                        description: |-
+                          DeploymentStrategy describes how to replace existing pods with new ones
+                          Default value is RollingUpdate with MaxUnavailable and MaxSurege as 25% (kubernetes default)
+                        properties:
+                          rollingUpdate:
+                            description: |-
+                              Rolling update config params. Present only if DeploymentStrategyType =
+                              RollingUpdate.
+                              ---
+                              TODO: Update this to follow our convention for oneOf, whatever we decide it
+                              to be.
+                            properties:
+                              maxSurge:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  The maximum number of pods that can be scheduled above the desired number of
+                                  pods.
+                                  Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                                  This can not be 0 if MaxUnavailable is 0.
+                                  Absolute number is calculated from percentage by rounding up.
+                                  Defaults to 25%.
+                                  Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when
+                                  the rolling update starts, such that the total number of old and new pods do not exceed
+                                  130% of desired pods. Once old pods have been killed,
+                                  new ReplicaSet can be scaled up further, ensuring that total number of pods running
+                                  at any time during the update is at most 130% of desired pods.
+                                x-kubernetes-int-or-string: true
+                              maxUnavailable:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  The maximum number of pods that can be unavailable during the update.
+                                  Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                                  Absolute number is calculated from percentage by rounding down.
+                                  This can not be 0 if MaxSurge is 0.
+                                  Defaults to 25%.
+                                  Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods
+                                  immediately when the rolling update starts. Once new pods are ready, old ReplicaSet
+                                  can be scaled down further, followed by scaling up the new ReplicaSet, ensuring
+                                  that the total number of pods available at all times during the update is at
+                                  least 70% of desired pods.
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          type:
+                            description: Type of deployment. Can be "Recreate" or
+                              "RollingUpdate". Default is RollingUpdate.
+                            type: string
+                        type: object
                       imagePullPolicy:
                         description: To indicate the image pull policy to be applied
                           to all the containers in the csi driver pods.

--- a/deploy/all-in-one/install.yaml
+++ b/deploy/all-in-one/install.yaml
@@ -1249,6 +1249,58 @@ spec:
                       type: string
                     description: Pod's annotations
                     type: object
+                  deploymentStrategy:
+                    description: |-
+                      DeploymentStrategy describes how to replace existing pods with new ones
+                      Default value is RollingUpdate with MaxUnavailable and MaxSurege as 25% (kubernetes default)
+                    properties:
+                      rollingUpdate:
+                        description: |-
+                          Rolling update config params. Present only if DeploymentStrategyType =
+                          RollingUpdate.
+                          ---
+                          TODO: Update this to follow our convention for oneOf, whatever we decide it
+                          to be.
+                        properties:
+                          maxSurge:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              The maximum number of pods that can be scheduled above the desired number of
+                              pods.
+                              Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                              This can not be 0 if MaxUnavailable is 0.
+                              Absolute number is calculated from percentage by rounding up.
+                              Defaults to 25%.
+                              Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when
+                              the rolling update starts, such that the total number of old and new pods do not exceed
+                              130% of desired pods. Once old pods have been killed,
+                              new ReplicaSet can be scaled up further, ensuring that total number of pods running
+                              at any time during the update is at most 130% of desired pods.
+                            x-kubernetes-int-or-string: true
+                          maxUnavailable:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              The maximum number of pods that can be unavailable during the update.
+                              Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                              Absolute number is calculated from percentage by rounding down.
+                              This can not be 0 if MaxSurge is 0.
+                              Defaults to 25%.
+                              Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods
+                              immediately when the rolling update starts. Once new pods are ready, old ReplicaSet
+                              can be scaled down further, followed by scaling up the new ReplicaSet, ensuring
+                              that the total number of pods available at all times during the update is at
+                              least 70% of desired pods.
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      type:
+                        description: Type of deployment. Can be "Recreate" or "RollingUpdate".
+                          Default is RollingUpdate.
+                        type: string
+                    type: object
                   imagePullPolicy:
                     description: To indicate the image pull policy to be applied to
                       all the containers in the csi driver pods.
@@ -8056,6 +8108,58 @@ spec:
                         additionalProperties:
                           type: string
                         description: Pod's annotations
+                        type: object
+                      deploymentStrategy:
+                        description: |-
+                          DeploymentStrategy describes how to replace existing pods with new ones
+                          Default value is RollingUpdate with MaxUnavailable and MaxSurege as 25% (kubernetes default)
+                        properties:
+                          rollingUpdate:
+                            description: |-
+                              Rolling update config params. Present only if DeploymentStrategyType =
+                              RollingUpdate.
+                              ---
+                              TODO: Update this to follow our convention for oneOf, whatever we decide it
+                              to be.
+                            properties:
+                              maxSurge:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  The maximum number of pods that can be scheduled above the desired number of
+                                  pods.
+                                  Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                                  This can not be 0 if MaxUnavailable is 0.
+                                  Absolute number is calculated from percentage by rounding up.
+                                  Defaults to 25%.
+                                  Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when
+                                  the rolling update starts, such that the total number of old and new pods do not exceed
+                                  130% of desired pods. Once old pods have been killed,
+                                  new ReplicaSet can be scaled up further, ensuring that total number of pods running
+                                  at any time during the update is at most 130% of desired pods.
+                                x-kubernetes-int-or-string: true
+                              maxUnavailable:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  The maximum number of pods that can be unavailable during the update.
+                                  Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                                  Absolute number is calculated from percentage by rounding down.
+                                  This can not be 0 if MaxSurge is 0.
+                                  Defaults to 25%.
+                                  Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods
+                                  immediately when the rolling update starts. Once new pods are ready, old ReplicaSet
+                                  can be scaled down further, followed by scaling up the new ReplicaSet, ensuring
+                                  that the total number of pods available at all times during the update is at
+                                  least 70% of desired pods.
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          type:
+                            description: Type of deployment. Can be "Recreate" or
+                              "RollingUpdate". Default is RollingUpdate.
+                            type: string
                         type: object
                       imagePullPolicy:
                         description: To indicate the image pull policy to be applied

--- a/deploy/multifile/crd.yaml
+++ b/deploy/multifile/crd.yaml
@@ -1240,6 +1240,58 @@ spec:
                       type: string
                     description: Pod's annotations
                     type: object
+                  deploymentStrategy:
+                    description: |-
+                      DeploymentStrategy describes how to replace existing pods with new ones
+                      Default value is RollingUpdate with MaxUnavailable and MaxSurege as 25% (kubernetes default)
+                    properties:
+                      rollingUpdate:
+                        description: |-
+                          Rolling update config params. Present only if DeploymentStrategyType =
+                          RollingUpdate.
+                          ---
+                          TODO: Update this to follow our convention for oneOf, whatever we decide it
+                          to be.
+                        properties:
+                          maxSurge:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              The maximum number of pods that can be scheduled above the desired number of
+                              pods.
+                              Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                              This can not be 0 if MaxUnavailable is 0.
+                              Absolute number is calculated from percentage by rounding up.
+                              Defaults to 25%.
+                              Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when
+                              the rolling update starts, such that the total number of old and new pods do not exceed
+                              130% of desired pods. Once old pods have been killed,
+                              new ReplicaSet can be scaled up further, ensuring that total number of pods running
+                              at any time during the update is at most 130% of desired pods.
+                            x-kubernetes-int-or-string: true
+                          maxUnavailable:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              The maximum number of pods that can be unavailable during the update.
+                              Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                              Absolute number is calculated from percentage by rounding down.
+                              This can not be 0 if MaxSurge is 0.
+                              Defaults to 25%.
+                              Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods
+                              immediately when the rolling update starts. Once new pods are ready, old ReplicaSet
+                              can be scaled down further, followed by scaling up the new ReplicaSet, ensuring
+                              that the total number of pods available at all times during the update is at
+                              least 70% of desired pods.
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      type:
+                        description: Type of deployment. Can be "Recreate" or "RollingUpdate".
+                          Default is RollingUpdate.
+                        type: string
+                    type: object
                   imagePullPolicy:
                     description: To indicate the image pull policy to be applied to
                       all the containers in the csi driver pods.
@@ -8047,6 +8099,58 @@ spec:
                         additionalProperties:
                           type: string
                         description: Pod's annotations
+                        type: object
+                      deploymentStrategy:
+                        description: |-
+                          DeploymentStrategy describes how to replace existing pods with new ones
+                          Default value is RollingUpdate with MaxUnavailable and MaxSurege as 25% (kubernetes default)
+                        properties:
+                          rollingUpdate:
+                            description: |-
+                              Rolling update config params. Present only if DeploymentStrategyType =
+                              RollingUpdate.
+                              ---
+                              TODO: Update this to follow our convention for oneOf, whatever we decide it
+                              to be.
+                            properties:
+                              maxSurge:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  The maximum number of pods that can be scheduled above the desired number of
+                                  pods.
+                                  Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                                  This can not be 0 if MaxUnavailable is 0.
+                                  Absolute number is calculated from percentage by rounding up.
+                                  Defaults to 25%.
+                                  Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when
+                                  the rolling update starts, such that the total number of old and new pods do not exceed
+                                  130% of desired pods. Once old pods have been killed,
+                                  new ReplicaSet can be scaled up further, ensuring that total number of pods running
+                                  at any time during the update is at most 130% of desired pods.
+                                x-kubernetes-int-or-string: true
+                              maxUnavailable:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  The maximum number of pods that can be unavailable during the update.
+                                  Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                                  Absolute number is calculated from percentage by rounding down.
+                                  This can not be 0 if MaxSurge is 0.
+                                  Defaults to 25%.
+                                  Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods
+                                  immediately when the rolling update starts. Once new pods are ready, old ReplicaSet
+                                  can be scaled down further, followed by scaling up the new ReplicaSet, ensuring
+                                  that the total number of pods available at all times during the update is at
+                                  least 70% of desired pods.
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          type:
+                            description: Type of deployment. Can be "Recreate" or
+                              "RollingUpdate". Default is RollingUpdate.
+                            type: string
                         type: object
                       imagePullPolicy:
                         description: To indicate the image pull policy to be applied

--- a/internal/controller/defaults.go
+++ b/internal/controller/defaults.go
@@ -50,10 +50,18 @@ var defaultLeaderElection = csiv1a1.LeaderElectionSpec{
 	RetryPeriod:   26,
 }
 
-var defautUpdateStrategy = appsv1.DaemonSetUpdateStrategy{
+var defaultDaemonSetUpdateStrategy = appsv1.DaemonSetUpdateStrategy{
 	Type: appsv1.RollingUpdateDaemonSetStrategyType,
 	RollingUpdate: &appsv1.RollingUpdateDaemonSet{
 		MaxUnavailable: ptr.To(intstr.FromInt(1)),
+	},
+}
+
+var defaultDeploymentStrategy = appsv1.DeploymentStrategy{
+	Type: appsv1.RollingUpdateDeploymentStrategyType,
+	RollingUpdate: &appsv1.RollingUpdateDeployment{
+		MaxSurge:       ptr.To(intstr.FromString("25%")),
+		MaxUnavailable: ptr.To(intstr.FromString("25%")),
 	},
 }
 

--- a/internal/controller/driver_controller.go
+++ b/internal/controller/driver_controller.go
@@ -564,6 +564,7 @@ func (r *driverReconcile) reconcileControllerPluginDeployment() error {
 		deploy.Spec = appsv1.DeploymentSpec{
 			Replicas: pluginSpec.Replicas,
 			Selector: &appSelector,
+			Strategy: ptr.Deref(pluginSpec.DeploymentStrategy, defaultDeploymentStrategy),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: utils.Call(func() map[string]string {
@@ -957,7 +958,7 @@ func (r *driverReconcile) reconcileNodePluginDeamonSet() error {
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{"app": appName},
 			},
-			UpdateStrategy: ptr.Deref(pluginSpec.UpdateStrategy, defautUpdateStrategy),
+			UpdateStrategy: ptr.Deref(pluginSpec.UpdateStrategy, defaultDaemonSetUpdateStrategy),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: utils.Call(func() map[string]string {

--- a/vendor/github.com/ceph/ceph-csi-operator/api/v1alpha1/driver_types.go
+++ b/vendor/github.com/ceph/ceph-csi-operator/api/v1alpha1/driver_types.go
@@ -213,6 +213,11 @@ type ControllerPluginSpec struct {
 	// Embedded common pods spec
 	PodCommonSpec `json:",inline"`
 
+	// DeploymentStrategy describes how to replace existing pods with new ones
+	// Default value is RollingUpdate with MaxUnavailable and MaxSurege as 25% (kubernetes default)
+	//+kubebuilder:validation:Optional
+	DeploymentStrategy *appsv1.DeploymentStrategy `json:"deploymentStrategy,omitempty"`
+
 	// Set replicas for controller plugin's deployment. Defaults to 2
 	//+kubebuilder:validation:Optional
 	//+kubebuilder:validation:Minimum:=1

--- a/vendor/github.com/ceph/ceph-csi-operator/api/v1alpha1/zz_generated.deepcopy.go
+++ b/vendor/github.com/ceph/ceph-csi-operator/api/v1alpha1/zz_generated.deepcopy.go
@@ -438,6 +438,11 @@ func (in *ControllerPluginResourcesSpec) DeepCopy() *ControllerPluginResourcesSp
 func (in *ControllerPluginSpec) DeepCopyInto(out *ControllerPluginSpec) {
 	*out = *in
 	in.PodCommonSpec.DeepCopyInto(&out.PodCommonSpec)
+	if in.DeploymentStrategy != nil {
+		in, out := &in.DeploymentStrategy, &out.DeploymentStrategy
+		*out = new(appsv1.DeploymentStrategy)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Replicas != nil {
 		in, out := &in.Replicas, &out.Replicas
 		*out = new(int32)


### PR DESCRIPTION
default value is choosen in such a way to make kubernetes replace one replica when there are 2 replicas running on 2 distinct nodes.

since these replicas are already using leader election a loss of 1 replica during rollout doesn't pose any issues.

minor: fixed a typo `s/defautUpdateStrategy/defaultUpdateStrategy/`

fixes: #140