### PR TITLE
docs: clarify the  operator design doc a bit

### DIFF
--- a/docs/design/operator.md
+++ b/docs/design/operator.md
@@ -54,12 +54,12 @@ graph TD
 
 In this diagram:
 
-- **CRD Changes**: Represents changes made to Custom Resource Definitions,
+- **CR Changes**: Represents changes made to Custom Resources (CRs),
   which trigger actions in the operator.
-- **Operator**: Listens for changes in CRDs and initiates the installation and
+- **Operator**: Listens for changes in CRs and initiates the installation and
   configuration of CSI drivers.
 - **Configure CephFS, NFS, RBD**: Actions performed by the operator to install
-  and configure the respective CSI drivers based on the CRD changes.
+  and configure the respective CSI drivers based on the configuration presented on the updated CR.
 
 ## CRDs for ceph-csi-operator
 


### PR DESCRIPTION
I the operator design document, custom resource definition(CRD) seems to have been used as a synonym for custom resource(CR) which is usually not correct.

This change makes the wording a little clearer  by using CRD only when technically correct and using CR when appropriate.


# Describe what this PR does #

Make some wording in the operator design doc a little clearer and more correct.

## Is there anything that requires special attention ##

no

Do you have any questions?

no

Is the change backward compatible?

yes

Are there concerns around backward compatibility?

no

Provide any external context for the change, if any.

none


## Related issues ##

none


## Future concerns ##

none

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi-operator/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi-operator/blob/devel/docs/development-guide.md#development-workflow)
* [x] [Pending release
  notes](https://github.com/ceph/ceph-csi-operator/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [x] Documentation has been updated, if necessary.
* [x] Unit tests have been added, if necessary.
* [x] Integration tests have been added, if necessary.
