### PR TITLE
Fix broken links in the  PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -38,11 +38,11 @@ functionality, but are work items that can be taken up subsequently.
 
 * [ ] **Commit Message Formatting**: Commit titles and messages follow
   guidelines in the [developer
-  guide](https://github.com/ceph/ceph-csi-operator/blob/devel/docs/development-guide.md#commit-messages).
+  guide](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#commit-messages).
 * [ ] Reviewed the developer guide on [Submitting a Pull
-  Request](https://github.com/ceph/ceph-csi-operator/blob/devel/docs/development-guide.md#development-workflow)
+  Request](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#development-workflow)
 * [ ] [Pending release
-  notes](https://github.com/ceph/ceph-csi-operator/blob/devel/PendingReleaseNotes.md)
+  notes](https://github.com/ceph/ceph-csi-operator/blob/main/PendingReleaseNotes.md)
   updated with breaking and/or notable changes for the next major release.
 * [ ] Documentation has been updated, if necessary.
 * [ ] Unit tests have been added, if necessary.


### PR DESCRIPTION
Links were broken due to using a nonexistent devel branch. 
Fix this by using `main`instead. 


# Describe what this PR does #

This fixes broken links in the PR template.

## Is there anything that requires special attention ##

no

Do you have any questions?

no

Is the change backward compatible?

yes

Are there concerns around backward compatibility?

no

Provide any external context for the change, if any.

none

## Related issues ##


Fixes: #168

## Future concerns ##

none
**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi-operator/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi-operator/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi-operator/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.
