### PR TITLE
docs: add design for enforcing host network.

### DIFF
--- a/docs/design/hostNetwork.md
+++ b/docs/design/hostNetwork.md
@@ -1,0 +1,45 @@
+# Enabling host networking for controller plugin pods
+
+By default, the Ceph-CSI controller plugins operate on the pod network
+but under some circumstances, like setups with a dedicated storage network, 
+where the pod network cannot connect to the ceph cluster,
+it is necessary to run the Ceph-CSI controller plugin pods on the host network.
+
+This document describes how the ceph-csi-operator can be configured to enforce the use of host network
+in the Ceph-CSI controller plugin pods
+
+The use of host networking can be enabled for a driver's controller plugin by setting `hostNetwork` to `true`in the `ControllerPlugin` section of the corresponding Driver CR.
+
+The `hostNetwork` setting is also available in the `driverSpecDefaults.controllerPlugin` section
+of the `OperatorConfig` CR. As this is a default for all Ceph-CSI controller plugins created by the operator, the setting
+in concrete Driver CRs will take precedence.
+
+There is currently no means of enforcing the use of host networking on all controller plugins against `Driver` CR settings.
+
+Example:
+
+## OperatorConfig CR
+
+```yaml
+kind: OperatorConfig 
+apiVersion: csi.ceph.io/v1alpha1
+metadata:
+  name: ceph-csi-operator-config
+  namespace: <operator-namespace>
+spec:
+   driverSpecDefaults:
+     controllerPlugin:
+       hostNetwork: true
+```
+## Driver CR
+
+```yaml
+apiVersion: csi.ceph.io/v1alpha1
+kind: Driver
+metadata:
+  name: rbd.csi.ceph.com
+  namespace: <operator-namespace> 
+spec:
+   controllerPlugin:
+     hostNetwork: false
+```


### PR DESCRIPTION
# Describe what this PR does #

This PR adds a design document for a way to  enable  the use of host networking on Ceph-CSI controller plugin pods.



## Is there anything that requires special attention ##





Is the change backward compatible?

yes as it is only adding a document.

Are there concerns around backward compatibility?

none


## Related issues ##

Mention any github issues relevant to this PR. Adding below line
will help to auto close the issue once the PR is merged.

It is a first step toward a solution for issue #157 

but not an implementation and hence not a complete solution yet.


## Future concerns ##

none. 

**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi-operator/blob/main/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.
