### PR TITLE
csiaddons: add rbac permission for setting ownerRef

### DIFF
--- a/config/csi-rbac/cephfs_ctrlplugin_role.yaml
+++ b/config/csi-rbac/cephfs_ctrlplugin_role.yaml
@@ -15,3 +15,6 @@ rules:
   - apiGroups: ["apps"]
     resources: ["replicasets"]
     verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["deployments/finalizers", "daemonsets/finalizers"]
+    verbs: ["update"]

--- a/config/csi-rbac/rbd_ctrlplugin_role.yaml
+++ b/config/csi-rbac/rbd_ctrlplugin_role.yaml
@@ -15,3 +15,6 @@ rules:
   - apiGroups: ["apps"]
     resources: ["replicasets"]
     verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["deployments/finalizers", "daemonsets/finalizers"]
+    verbs: ["update"]

--- a/config/csi-rbac/rbd_nodeplugin_role.yaml
+++ b/config/csi-rbac/rbd_nodeplugin_role.yaml
@@ -12,3 +12,6 @@ rules:
   - apiGroups: ["apps"]
     resources: ["replicasets"]
     verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["deployments/finalizers", "daemonsets/finalizers"]
+    verbs: ["update"]

--- a/deploy/all-in-one/install.yaml
+++ b/deploy/all-in-one/install.yaml
@@ -14112,6 +14112,13 @@ rules:
   - replicasets
   verbs:
   - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  - daemonsets/finalizers
+  verbs:
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -14191,6 +14198,13 @@ rules:
   - replicasets
   verbs:
   - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  - daemonsets/finalizers
+  verbs:
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -14218,6 +14232,13 @@ rules:
   - replicasets
   verbs:
   - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  - daemonsets/finalizers
+  verbs:
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/deploy/multifile/csi-rbac.yaml
+++ b/deploy/multifile/csi-rbac.yaml
@@ -71,6 +71,13 @@ rules:
   - replicasets
   verbs:
   - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  - daemonsets/finalizers
+  verbs:
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -109,6 +116,13 @@ rules:
   - replicasets
   verbs:
   - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  - daemonsets/finalizers
+  verbs:
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -136,6 +150,13 @@ rules:
   - replicasets
   verbs:
   - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  - daemonsets/finalizers
+  verbs:
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
# Describe what this PR does #

csiaddons require new RBAC permission for setting onwerRef on csiaddonsnode obj, going to be owned by either a deployment or a daemonsets. 

continued from: https://github.com/ceph/ceph-csi-operator/pull/166

## Is there anything that requires special attention ##

Do you have any questions?
No

Is the change backward compatible?
Yes

Are there concerns around backward compatibility?
No

Provide any external context for the change, if any.
RBAC's are required for this new change https://github.com/csi-addons/kubernetes-csi-addons/pull/695

For example:

* Kubernetes links that explain why the change is required
* Ceph-CSI spec related changes/catch-up that necessitates this patch
* golang related practices that necessitates this change

## Related issues ##

Mention any github issues relevant to this PR. Adding below line
will help to auto close the issue once the PR is merged.

Fixes: #issue_number

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi-operator/blob/main/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.
