### PR TITLE
docs: add design for adding new arguments for TLS

### DIFF
--- a/docs/design/podService.md
+++ b/docs/design/podService.md
@@ -1,0 +1,24 @@
+# Add support for TLS certificates for CSI Addons communication
+
+The Kubernetes CSI Addons project currently connects the CSI Addons Manager to the add-on sidecar without TLS in place.
+We propose a introduction of an arugment which enabled should mount the TLS certificates into the sidecar container.
+The operator is only responsible for propagation of the certificates.
+
+## Problem Statement
+
+CSI addons sidecar which is being deployed here needs certificates. Currently we have no argument to enable this propagation of certificates.
+
+## Proposed Solution
+
+###  Introduce a new argument for TLS
+
+We introduce a new argument in the commands to enable TLS. It is diabled by default. But if this is enabled the deployer is expected to have mounted a secret that contains the required certificates. We will essentially need a certifiate that is compatible with the hostname that the manager will be issuing network calls using it. 
+
+
+### Operator changes
+
+The Ceph CSI Operator is only responsible for taking in the information mounted to it and project those as volumes in the CSI Addons sidecar. The deployer of CSI Addons should create these certificates and mount it at `/etc/tls/tls.crt` and `/etc/tls/tls.key`. We keep this hardcoded to reduce the number of new arguments introduced. The logger should provide enough information if the user is not mounting this correctly for easy debugging.
+
+## Guide to the deployeer for handling certificates
+
+Since we use host networking the certificates should have these IP addresses as valid Subject names.


### PR DESCRIPTION
# Describe what this PR does #

This PR adds a design doc, proposing the introduction of Services in front of pods that have addons sidecar container running in them.

## Is there anything that requires special attention ##

Do you have any questions?

Is the change backward compatible?
Yes

Are there concerns around backward compatibility?
No

Provide any external context for the change, if any.

The addition of Service is required to allow secure communication between the add-ons manager and the sidecar. Related PR on the addons repo:  https://github.com/csi-addons/kubernetes-csi-addons/pull/692/

## Related issues ##

https://github.com/csi-addons/kubernetes-csi-addons/pull/692/
https://github.com/ceph/ceph-csi-operator/pull/172

**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi-operator/blob/main/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.
