### PR TITLE
 fix the  Driver controller and ClientProfile controller  unit tests

### DIFF
--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -1,0 +1,33 @@
+name: Unit Tests
+on:
+  pull_request:
+    paths-ignore:
+      - 'vendor/*'
+    branches:
+      - main
+      - release-*
+
+# cancel the in-progress workflow when PR is refreshed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+    unittests:
+      name: unittests
+      runs-on: ubuntu-latest
+      steps:
+        - name: checkout     
+          uses: actions/checkout@v4
+          with:
+            fetch-depth: 1
+        - name: setup go    
+          uses: actions/setup-go@v5
+          with: 
+            go-version-file: go.mod
+            check-latest: true
+        - name:  run unit tests
+          run:   make test

--- a/internal/controller/driver_controller_test.go
+++ b/internal/controller/driver_controller_test.go
@@ -32,7 +32,7 @@ import (
 
 var _ = Describe("Driver Controller", func() {
 	Context("When reconciling a resource", func() {
-		const resourceName = "test-resource"
+		const resourceName = "test.rbd.csi.ceph.com"
 
 		ctx := context.Background()
 


### PR DESCRIPTION

# Describe what this PR does #

This PR fixes `make test`failures. (see issue #174 for details on the failures. 

## Is there anything that requires special attention ##

I am not certain why current `main` branch has this issue but it was possible to get PRs with all CI check passing.  


Is the change backward compatible?

yes.


Are there concerns around backward compatibility?

no

Provide any external context for the change, if any.

This patch was created in collaboration with @raghavendra-talur .
Many thanks for the help! 


## Related issues ##


Fixes: #174 

## Future concerns ##

no concerns.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#development-workflow)
* [x] [Pending release
  notes](https://github.com/ceph/ceph-csi-operator/blob/main/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [x] Documentation has been updated, if necessary.
* [x] Unit tests have been added, if necessary.
* [x] Integration tests have been added, if necessary.
