### PR TITLE
Make it easy to run a single test

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -94,6 +94,9 @@ func main() {
 		TLSOpts: tlsOpts,
 	})
 
+	// Init the config options from the environment
+	controller.InitConfig()
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{

--- a/internal/controller/defaults.go
+++ b/internal/controller/defaults.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/utils/ptr"
 
 	csiv1a1 "github.com/ceph/ceph-csi-operator/api/v1alpha1"
-	"github.com/ceph/ceph-csi-operator/internal/utils"
 )
 
 var imageDefaults = map[string]string{
@@ -65,25 +64,26 @@ var defaultDeploymentStrategy = appsv1.DeploymentStrategy{
 	},
 }
 
-var operatorNamespace = utils.Call(func() string {
-	namespace := os.Getenv("OPERATOR_NAMESPACE")
-	if namespace == "" {
+var (
+	operatorNamespace    string
+	operatorConfigName   string
+	serviceAccountPrefix string
+)
+
+func InitConfig() {
+	if operatorNamespace = os.Getenv("OPERATOR_NAMESPACE"); operatorNamespace == "" {
 		panic("Required OPERATOR_NAMESPACE environment variable is either missing or empty")
 	}
-	return namespace
-})
 
-var operatorConfigName = utils.Call(func() string {
-	name, ok := os.LookupEnv("OPERATOR_CONFIG_NAME")
-	if ok {
-		if name == "" {
+	serviceAccountPrefix = os.Getenv("CSI_SERVICE_ACCOUNT_PREFIX")
+
+	envOperatorConfigName, set := os.LookupEnv("OPERATOR_CONFIG_NAME")
+	if set {
+		if envOperatorConfigName == "" {
 			panic("OPERATOR_CONFIG_NAME exists but empty")
 		}
-		return name
+		operatorConfigName = envOperatorConfigName
+	} else {
+		operatorConfigName = "ceph-csi-operator-config"
 	}
-	return "ceph-csi-operator-config"
-})
-
-var serviceAccountPrefix = utils.Call(func() string {
-	return os.Getenv("CSI_SERVICE_ACCOUNT_PREFIX")
-})
+}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi-operator! -->

# Describe what this PR does #
This PR moves the config init code to the main function from the global init. Doing so, it allows for such config init to be skipped for tests or other scenarios.

In the second commit, we set the os environment variable for the operator namespace in the BeforeSuite() function if it is not already set. This allows users to run a specific test by using the ginkgo cli or by using the test decorators in vscode.

For example:

```
$ ginkgo -focus "ClientProfile Controller" -r
[1732083376] Controller Suite - 1/3 specs SS• SUCCESS! 5.797831s PASS
  Starting ceph-csi-operator suite
[1732083376] e2e suite - 0/1 specs S SUCCESS! 59.25µs PASS

Ginkgo ran 2 suites in 10.605577042s
Test Suite Passed
```

<img width="645" alt="Screenshot 2024-11-20 at 1 24 33 AM" src="https://github.com/user-attachments/assets/2dc74071-9a1b-4cda-b192-ed1a9c640769">


Provide some context for the reviewer

## Is there anything that requires special attention ##
Earlier, the configuration was automatically inited. Now, it is being done manually in the main function. 

Is the change backward compatible?
Yes

Are there concerns around backward compatibility?
No



**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#development-workflow)
* [x] [Pending release
  notes](https://github.com/ceph/ceph-csi-operator/blob/main/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [x] Documentation has been updated, if necessary.
* [x] Unit tests have been added, if necessary.
* [x] Integration tests have been added, if necessary.
