### PR TITLE
Update externalsnapshotter volumegroupsnapshot container arg

### DIFF
--- a/internal/controller/defaults.go
+++ b/internal/controller/defaults.go
@@ -31,7 +31,7 @@ var imageDefaults = map[string]string{
 	"provisioner": "registry.k8s.io/sig-storage/csi-provisioner:v5.0.1",
 	"attacher":    "registry.k8s.io/sig-storage/csi-attacher:v4.6.1",
 	"resizer":     "registry.k8s.io/sig-storage/csi-resizer:v1.11.1",
-	"snapshotter": "registry.k8s.io/sig-storage/csi-snapshotter:v8.0.1",
+	"snapshotter": "registry.k8s.io/sig-storage/csi-snapshotter:v8.2.0",
 	"registrar":   "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.11.1",
 	"plugin":      "quay.io/cephcsi/cephcsi:v3.12.2",
 	"addons":      "quay.io/csiaddons/k8s-sidecar:v0.10.0",

--- a/internal/utils/csi.go
+++ b/internal/utils/csi.go
@@ -368,7 +368,7 @@ var PreventVolumeModeConversionContainerArg = "--prevent-volume-mode-conversion=
 var HonorPVReclaimPolicyContainerArg = "--feature-gates=HonorPVReclaimPolicy=true"
 var ImmediateTopologyContainerArg = "--immediate-topology=false"
 var RecoverVolumeExpansionFailureContainerArg = "--feature-gates=RecoverVolumeExpansionFailure=true"
-var EnableVolumeGroupSnapshotsContainerArg = "--enable-volume-group-snapshots=true"
+var EnableVolumeGroupSnapshotsContainerArg = "--feature-gates=CSIVolumeGroupSnapshot=true"
 var ForceCephKernelClientContainerArg = "--forcecephkernelclient=true"
 var LogToStdErrContainerArg = "--logtostderr=false"
 var AlsoLogToStdErrContainerArg = "--alsologtostderr=true"


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi-operator! -->

# Describe what this PR does #

In external-snapshotter the groupsnapshot feature flag is moved to a new container argument and the old enable-volumegroup-snapshot flag is removed, This PR updates the flag to use external-snapshotter latest version,

Note:- As the flag is removed from external-snapshotter  the user cannot test/use the older version of external-snapshotter for groupsnapshot feature, but all other features will be still supported with older releases.

## Is there anything that requires special attention ##

Do you have any questions?

Is the change backward compatible?

Are there concerns around backward compatibility?

Provide any external context for the change, if any.

For example:

* Kubernetes links that explain why the change is required
* Ceph-CSI spec related changes/catch-up that necessitates this patch
* golang related practices that necessitates this change

## Related issues ##

Mention any github issues relevant to this PR. Adding below line
will help to auto close the issue once the PR is merged.

Fixes: #issue_number

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi-operator/blob/main/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.


Marking it as draft until we have next release of external-snapshotter