### PR TITLE
restrict manager resource cache based on namespaces from environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ IMAGE_NAME ?= ceph-csi-operator
 # Allow customization of the name prefix and/or namespace
 NAME_PREFIX ?= ceph-csi-operator-
 NAMESPACE ?= $(NAME_PREFIX)system
+# A comma separated list of namespaces for operator to cache objects from
+WATCH_NAMESPACE ?= ""
 
 IMG ?= $(IMAGE_REGISTRY)/$(REGISTRY_NAMESPACE)/$(IMAGE_NAME):$(IMAGE_TAG)
 
@@ -47,6 +49,11 @@ patches:
       value:
         name: CSI_SERVICE_ACCOUNT_PREFIX
         value: $(NAME_PREFIX)
+    - op: add
+      path: /spec/template/spec/containers/1/env/-
+      value:
+        name: WATCH_NAMESPACE
+        value: $(WATCH_NAMESPACE)
   target:
     kind: Deployment
     name: controller-manager

--- a/deploy/all-in-one/install.yaml
+++ b/deploy/all-in-one/install.yaml
@@ -15496,6 +15496,8 @@ spec:
               fieldPath: metadata.namespace
         - name: CSI_SERVICE_ACCOUNT_PREFIX
           value: ceph-csi-operator-
+        - name: WATCH_NAMESPACE
+          value: ""
         image: quay.io/cephcsi/ceph-csi-operator:latest
         livenessProbe:
           httpGet:

--- a/deploy/multifile/operator.yaml
+++ b/deploy/multifile/operator.yaml
@@ -628,6 +628,8 @@ spec:
               fieldPath: metadata.namespace
         - name: CSI_SERVICE_ACCOUNT_PREFIX
           value: ceph-csi-operator-
+        - name: WATCH_NAMESPACE
+          value: ""
         image: quay.io/cephcsi/ceph-csi-operator:latest
         livenessProbe:
           httpGet:

--- a/internal/controller/defaults.go
+++ b/internal/controller/defaults.go
@@ -66,8 +66,8 @@ var defaultDeploymentStrategy = appsv1.DeploymentStrategy{
 }
 
 var operatorNamespace = utils.Call(func() string {
-	namespace := os.Getenv("OPERATOR_NAMESPACE")
-	if namespace == "" {
+	namespace, err := utils.GetOperatorNamespace()
+	if err != nil {
 		panic("Required OPERATOR_NAMESPACE environment variable is either missing or empty")
 	}
 	return namespace

--- a/internal/utils/core.go
+++ b/internal/utils/core.go
@@ -18,9 +18,15 @@ package utils
 
 import (
 	"cmp"
+	"fmt"
+	"os"
 	"slices"
 	"strings"
 	"sync"
+)
+
+const (
+	operatorNamespaceEnvVar = "OPERATOR_NAMESPACE"
 )
 
 // RunConcurrently runs all the of the given functions concurrently returning a channel with
@@ -128,4 +134,12 @@ func DeleteZeroValues[T comparable](slice []T) []T {
 	return slices.DeleteFunc(slice, func(value T) bool {
 		return value == zero
 	})
+}
+
+func GetOperatorNamespace() (string, error) {
+	ns := os.Getenv(operatorNamespaceEnvVar)
+	if ns == "" {
+		return "", fmt.Errorf("%s must be set", operatorNamespaceEnvVar)
+	}
+	return ns, nil
 }


### PR DESCRIPTION
always cache resources from operator deployed namespace and provider an option to user for caching resources from other namespaces via `WATCH_NAMESPACE` env var with a comma separated namespace values.

fixes: #184