### PR TITLE
Rework golangci lint

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -52,17 +52,8 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
-        with:
-          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.63
-
-          # Optional: golangci-lint command line arguments.
-          args: --config=.golangci.yml
-
-          # actions/setup-go already handles caching
-          skip-cache: true
+      - name: run golangci-lint
+        run: make golangci-lint
 
   govulncheck:
     name: govulncheck

--- a/Makefile
+++ b/Makefile
@@ -251,7 +251,7 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
 KUSTOMIZE_VERSION ?= v5.3.0
 CONTROLLER_TOOLS_VERSION ?= v0.14.0
 ENVTEST_VERSION ?= release-0.17
-GOLANGCI_LINT_VERSION ?= v1.57.2
+GOLANGCI_LINT_VERSION ?= v1.63.4
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.

--- a/Makefile
+++ b/Makefile
@@ -133,13 +133,17 @@ test: manifests generate fmt vet envtest ## Run tests.
 test-e2e:
 	go test ./test/e2e/ -v -ginkgo.v
 
-.PHONY: lint
-lint: golangci-lint ## Run golangci-lint linter & yamllint
-	$(GOLANGCI_LINT) run
 
+
+.PHONY:	golangci-lint-fix
+golangci-lint-fix: $(GOLANGCI_LINT) ## Run the golangci-lint linter and perform fixes
+	@$(GOLANGCI_LINT) --config=.golangci.yml -verbose run --fix
+
+
+.PHONY: lint
+lint: golangci-lint ## Run various linters
 .PHONY: lint-fix
-lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
-	$(GOLANGCI_LINT) run --fix
+lint-fix: golangci-lint-fix ## run linters and perform fixes
 
 ##@ Build
 
@@ -269,8 +273,9 @@ check-all-committed: ## Fail in case there are uncommitted changes
 	test -z "$(shell git status --short)" || (echo "files were modified: " ; git status --short ; false)
 
 .PHONY: golangci-lint
-golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
-$(GOLANGCI_LINT): $(LOCALBIN)
+golangci-lint: $(GOLANGCI_LINT) ## Run the golangci-lint linter
+	@$(GOLANGCI_LINT) --config=.golangci.yml -verbose run
+$(GOLANGCI_LINT): $(LOCALBIN) ## Download golangci-lint locally if necessary.
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,${GOLANGCI_LINT_VERSION})
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist


### PR DESCRIPTION


# Describe what this PR does #

This PR reworks the golangci-lint make targets a bit to make them more consistent and systematic.
While at it, it makes sure the same version of golangci-lint is used locally and in the CI.

Finally, the `lint` CI workflow is changed to use the golangci-lint make target instead of the corresponding github action. 



## Is there anything that requires special attention ##

Is the change backward compatible?

yes.

Are there concerns around backward compatibility?

no.





## Future concerns ##

none 
**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi-operator/blob/main/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [x] Unit tests have been added, if necessary.
* [x] Integration tests have been added, if necessary.
