### PR TITLE
csi: update RBACs for CSIAddonsNode

### DIFF
--- a/config/csi-rbac/cephfs_ctrlplugin_role.yaml
+++ b/config/csi-rbac/cephfs_ctrlplugin_role.yaml
@@ -8,7 +8,7 @@ rules:
     verbs: ["get", "watch", "list", "delete", "update", "create"]
   - apiGroups: ["csiaddons.openshift.io"]
     resources: ["csiaddonsnodes"]
-    verbs: ["get", "create", "update", "delete"]
+    verbs: ["get", "watch", "list", "create", "update", "delete"]
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get"]

--- a/config/csi-rbac/rbd_ctrlplugin_role.yaml
+++ b/config/csi-rbac/rbd_ctrlplugin_role.yaml
@@ -8,7 +8,7 @@ rules:
     verbs: ["get", "watch", "list", "delete", "update", "create"]
   - apiGroups: ["csiaddons.openshift.io"]
     resources: ["csiaddonsnodes"]
-    verbs: ["get", "create", "update", "delete"]
+    verbs: ["get", "watch", "list", "create", "update", "delete"]
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get"]

--- a/config/csi-rbac/rbd_nodeplugin_role.yaml
+++ b/config/csi-rbac/rbd_nodeplugin_role.yaml
@@ -5,7 +5,7 @@ metadata:
 rules:
   - apiGroups: ["csiaddons.openshift.io"]
     resources: ["csiaddonsnodes"]
-    verbs: ["get", "create", "update", "delete"]
+    verbs: ["get", "watch", "list", "create", "update", "delete"]
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get"]

--- a/deploy/all-in-one/install.yaml
+++ b/deploy/all-in-one/install.yaml
@@ -14106,6 +14106,8 @@ rules:
   - csiaddonsnodes
   verbs:
   - get
+  - watch
+  - list
   - create
   - update
   - delete
@@ -14199,6 +14201,8 @@ rules:
   - csiaddonsnodes
   verbs:
   - get
+  - watch
+  - list
   - create
   - update
   - delete
@@ -14240,6 +14244,8 @@ rules:
   - csiaddonsnodes
   verbs:
   - get
+  - watch
+  - list
   - create
   - update
   - delete

--- a/deploy/multifile/csi-rbac.yaml
+++ b/deploy/multifile/csi-rbac.yaml
@@ -57,6 +57,8 @@ rules:
   - csiaddonsnodes
   verbs:
   - get
+  - watch
+  - list
   - create
   - update
   - delete
@@ -109,6 +111,8 @@ rules:
   - csiaddonsnodes
   verbs:
   - get
+  - watch
+  - list
   - create
   - update
   - delete
@@ -150,6 +154,8 @@ rules:
   - csiaddonsnodes
   verbs:
   - get
+  - watch
+  - list
   - create
   - update
   - delete


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi-operator! -->

# Describe what this PR does #

This patch adds `watch` and `list` verbs for CSIAddonsNode objects.

These permissions are required by the csi-addons sidecar. Ref: https://github.com/csi-addons/kubernetes-csi-addons/pull/765

