### PR TITLE
csi: correct conditional logic for fuse mount options argument

### DIFF
--- a/internal/controller/driver_controller.go
+++ b/internal/controller/driver_controller.go
@@ -1560,6 +1560,9 @@ func mergeDriverSpecs(dest, src *csiv1a1.DriverSpec) {
 	if dest.KernelMountOptions == nil {
 		dest.KernelMountOptions = src.KernelMountOptions
 	}
+	if dest.FuseMountOptions == nil {
+		dest.FuseMountOptions = src.FuseMountOptions
+	}
 	if src.CephFsClientType != "" {
 		dest.CephFsClientType = src.CephFsClientType
 	}

--- a/internal/utils/csi.go
+++ b/internal/utils/csi.go
@@ -439,14 +439,14 @@ func LogRotateConfigMapName(driverName string) string {
 func KernelMountOptionsContainerArg(options map[string]string) string {
 	return If(
 		len(options) > 0,
-		fmt.Sprintf("--kernelmountoptions==%s", MapToString(options, "=", ",")),
+		fmt.Sprintf("--kernelmountoptions=%s", MapToString(options, "=", ",")),
 		"",
 	)
 }
 func FuseMountOptionsContainerArg(options map[string]string) string {
 	return If(
-		len(options) == 0,
-		fmt.Sprintf("--fusemountoptions==%s", MapToString(options, "=", ",")),
+		len(options) > 0,
+		fmt.Sprintf("--fusemountoptions=%s", MapToString(options, "=", ",")),
 		"",
 	)
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi-operator! -->

# Describe what this PR does #

Previously, the function incorrectly checked if `len(options) == 0`, causing it to return a non-empty argument when no options were provided. This fix updates the condition to `len(options) > 0`, ensuring the argument is only set when options exist.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#development-workflow)
* [x] [Pending release notes](https://github.com/ceph/ceph-csi-operator/blob/main/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [x] Documentation has been updated, if necessary.
* [x] Unit tests have been added, if necessary.
* [x] Integration tests have been added, if necessary.
