### PR TITLE
csi: add missing mount-info volumeMount for cephfs

### DIFF
--- a/internal/controller/driver_controller.go
+++ b/internal/controller/driver_controller.go
@@ -1076,6 +1076,9 @@ func (r *driverReconcile) reconcileNodePluginDeamonSet() error {
 									if r.driver.Spec.Encryption != nil {
 										mounts = append(mounts, utils.KmsConfigVolumeMount)
 									}
+									if r.isCephFsDriver() {
+										mounts = append(mounts, utils.CsiMountInfoVolumeMount)
+									}
 									if r.isRdbDriver() {
 										mounts = append(mounts, utils.OidcTokenVolumeMount)
 									}
@@ -1250,6 +1253,12 @@ func (r *driverReconcile) reconcileNodePluginDeamonSet() error {
 							utils.PodsMountDirVolume(kubeletDirPath),
 							utils.RegistrationDirVolume(kubeletDirPath),
 						)
+						if r.isCephFsDriver() {
+							volumes = append(
+								volumes,
+								utils.CsiMountInfoVolume(kubeletDirPath, r.driver.Name),
+							)
+						}
 						if ptr.Deref(pluginSpec.EnableSeLinuxHostMount, false) {
 							volumes = append(
 								volumes,

--- a/internal/utils/csi.go
+++ b/internal/utils/csi.go
@@ -30,6 +30,7 @@ const (
 	csiAddonsEndpoint = "unix://" + SocketDir + "/csi-addons.sock"
 
 	kmsConfigVolumeName      = "ceph-csi-kms-config"
+	csiMountInfoVolumeName   = "ceph-csi-mountinfo"
 	registrationVolumeName   = "registration-dir"
 	pluginDirVolumeName      = "plugin-dir"
 	podsMountDirVolumeName   = "pods-mount-dir"
@@ -126,6 +127,17 @@ var EtcSelinuxVolume = corev1.Volume{
 	},
 }
 
+func CsiMountInfoVolume(kubeletDirPath string, driverName string) corev1.Volume {
+	return corev1.Volume{
+		Name: csiMountInfoVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: fmt.Sprintf("%s/plugins/%s/mountinfo", kubeletDirPath, driverName),
+				Type: ptr.To(corev1.HostPathDirectoryOrCreate),
+			},
+		},
+	}
+}
 func KmsConfigVolume(configRef *corev1.LocalObjectReference) corev1.Volume {
 	return corev1.Volume{
 		Name: kmsConfigVolumeName,
@@ -244,6 +256,10 @@ var OidcTokenVolumeMount = corev1.VolumeMount{
 var CsiConfigVolumeMount = corev1.VolumeMount{
 	Name:      CsiConfigVolume.Name,
 	MountPath: "/etc/ceph-csi-config",
+}
+var CsiMountInfoVolumeMount = corev1.VolumeMount{
+	Name:      csiMountInfoVolumeName,
+	MountPath: "/csi/mountinfo",
 }
 var KmsConfigVolumeMount = corev1.VolumeMount{
 	Name:      kmsConfigVolumeName,


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi-operator! -->

# Describe what this PR does #

This file provides functionality to store various mount information in a file. It's currently used to restore ceph-fuse mounts. Mount info is stored in `/csi/mountinfo`.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#development-workflow)
* [x] [Pending release notes](https://github.com/ceph/ceph-csi-operator/blob/main/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [x] Documentation has been updated, if necessary.
* [x] Unit tests have been added, if necessary.
* [x] Integration tests have been added, if necessary.
