### PR TITLE
Fix RBAC permissions for CSI addons security enhancements

### DIFF
--- a/config/csi-rbac/cephfs_ctrlplugin_cluster_role.yaml
+++ b/config/csi-rbac/cephfs_ctrlplugin_cluster_role.yaml
@@ -63,3 +63,6 @@ rules:
   - apiGroups: [""]
     resources: ["serviceaccounts/token"]
     verbs: ["create"]
+  - apiGroups: ["authentication.k8s.io"]
+    resources: ["tokenreviews"]
+    verbs: ["create"]

--- a/config/csi-rbac/cephfs_ctrlplugin_role.yaml
+++ b/config/csi-rbac/cephfs_ctrlplugin_role.yaml
@@ -18,6 +18,3 @@ rules:
   - apiGroups: ["apps"]
     resources: ["deployments/finalizers", "daemonsets/finalizers"]
     verbs: ["update"]
-  - apiGroups: ["authentication.k8s.io"]
-    resources: ["tokenreviews"]
-    verbs: ["create"]

--- a/config/csi-rbac/rbd_ctrlplugin_cluster_role.yaml
+++ b/config/csi-rbac/rbd_ctrlplugin_cluster_role.yaml
@@ -69,3 +69,6 @@ rules:
   - apiGroups: ["replication.storage.openshift.io"]
     resources: ["volumegroupreplicationclasses"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["authentication.k8s.io"]
+    resources: ["tokenreviews"]
+    verbs: ["create"]

--- a/config/csi-rbac/rbd_ctrlplugin_role.yaml
+++ b/config/csi-rbac/rbd_ctrlplugin_role.yaml
@@ -18,6 +18,3 @@ rules:
   - apiGroups: ["apps"]
     resources: ["deployments/finalizers", "daemonsets/finalizers"]
     verbs: ["update"]
-  - apiGroups: ["authentication.k8s.io"]
-    resources: ["tokenreviews"]
-    verbs: ["create"]

--- a/config/csi-rbac/rbd_nodeplugin_cluster_role.yaml
+++ b/config/csi-rbac/rbd_nodeplugin_cluster_role.yaml
@@ -24,3 +24,6 @@ rules:
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get"]
+  - apiGroups: ["authentication.k8s.io"]
+    resources: ["tokenreviews"]
+    verbs: ["create"]

--- a/config/csi-rbac/rbd_nodeplugin_role.yaml
+++ b/config/csi-rbac/rbd_nodeplugin_role.yaml
@@ -15,6 +15,3 @@ rules:
   - apiGroups: ["apps"]
     resources: ["deployments/finalizers", "daemonsets/finalizers"]
     verbs: ["update"]
-  - apiGroups: ["authentication.k8s.io"]
-    resources: ["tokenreviews"]
-    verbs: ["create"]

--- a/deploy/all-in-one/install.yaml
+++ b/deploy/all-in-one/install.yaml
@@ -14130,12 +14130,6 @@ rules:
   - daemonsets/finalizers
   verbs:
   - update
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -14225,12 +14219,6 @@ rules:
   - daemonsets/finalizers
   verbs:
   - update
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -14268,12 +14256,6 @@ rules:
   - daemonsets/finalizers
   verbs:
   - update
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -14487,6 +14469,12 @@ rules:
   - ""
   resources:
   - serviceaccounts/token
+  verbs:
+  - create
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
   verbs:
   - create
 ---
@@ -15248,6 +15236,12 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -15299,6 +15293,12 @@ rules:
   - nodes
   verbs:
   - get
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/deploy/charts/ceph-csi-operator/templates/cephfs-ctrlplugin-cr-rbac.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/cephfs-ctrlplugin-cr-rbac.yaml
@@ -164,3 +164,9 @@ rules:
   - serviceaccounts/token
   verbs:
   - create
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create

--- a/deploy/charts/ceph-csi-operator/templates/cephfs-ctrlplugin-r-rbac.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/cephfs-ctrlplugin-r-rbac.yaml
@@ -46,9 +46,3 @@ rules:
   - daemonsets/finalizers
   verbs:
   - update
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create

--- a/deploy/charts/ceph-csi-operator/templates/rbd-ctrlplugin-cr-rbac.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/rbd-ctrlplugin-cr-rbac.yaml
@@ -181,3 +181,9 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create

--- a/deploy/charts/ceph-csi-operator/templates/rbd-ctrlplugin-r-rbac.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/rbd-ctrlplugin-r-rbac.yaml
@@ -46,9 +46,3 @@ rules:
   - daemonsets/finalizers
   verbs:
   - update
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create

--- a/deploy/charts/ceph-csi-operator/templates/rbd-nodeplugin-cr-rbac.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/rbd-nodeplugin-cr-rbac.yaml
@@ -50,3 +50,9 @@ rules:
   - nodes
   verbs:
   - get
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create

--- a/deploy/charts/ceph-csi-operator/templates/rbd-nodeplugin-r-rbac.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/rbd-nodeplugin-r-rbac.yaml
@@ -35,9 +35,3 @@ rules:
   - daemonsets/finalizers
   verbs:
   - update
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create

--- a/deploy/multifile/csi-rbac.yaml
+++ b/deploy/multifile/csi-rbac.yaml
@@ -81,12 +81,6 @@ rules:
   - daemonsets/finalizers
   verbs:
   - update
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -135,12 +129,6 @@ rules:
   - daemonsets/finalizers
   verbs:
   - update
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -178,12 +166,6 @@ rules:
   - daemonsets/finalizers
   verbs:
   - update
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -347,6 +329,12 @@ rules:
   - ""
   resources:
   - serviceaccounts/token
+  verbs:
+  - create
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
   verbs:
   - create
 ---
@@ -712,6 +700,12 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -763,6 +757,12 @@ rules:
   - nodes
   verbs:
   - get
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
# Describe what this PR does #

Updates RBAC configuration to support CSI addons security changes introduced in https://github.com/csi-addons/kubernetes-csi-addons/pull/692
TokenReview permission needs to be applied to ClusterRole previously it was applied to Role

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi-operator/blob/main/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [x] Documentation has been updated, if necessary.
* [x] Unit tests have been added, if necessary.
* [x] Integration tests have been added, if necessary.
