### PR TITLE
fix: set SELinuxMount to true

### DIFF
--- a/internal/controller/driver_controller.go
+++ b/internal/controller/driver_controller.go
@@ -465,12 +465,7 @@ func (r *driverReconcile) reconcileK8sCsiDriver() error {
 				storagev1.FileFSGroupPolicy,
 			),
 		)
-		if nodePlugin := r.driver.Spec.NodePlugin; nodePlugin != nil {
-			csiDriver.Spec.SELinuxMount = cmp.Or(
-				nodePlugin.EnableSeLinuxHostMount,
-				csiDriver.Spec.SELinuxMount,
-			)
-		}
+		csiDriver.Spec.SELinuxMount = ptr.To(true)
 
 		return nil
 	})


### PR DESCRIPTION
Setting SELinuxMount in the csi driver spec to true by default like we have it in Rook.

The Field we have it in the Driver spec EnableSeLinuxHostMount is to mount the below path to the csi driver daemonset as the Field description specifies.

https://github.com/ceph/ceph-csi-operator/blob/ae5677274f13fabf0aea26fbfbe2157817ed6046/api/v1alpha1/driver_types.go#L175-L177

```
-  name: etc-selinux
   mountPath: /etc/selinux
   readOnly: true
```

