### PR TITLE
fix: set topology flag if csi driver advertize it

### DIFF
--- a/internal/controller/driver_controller.go
+++ b/internal/controller/driver_controller.go
@@ -553,6 +553,10 @@ func (r *driverReconcile) reconcileControllerPluginDeployment() error {
 			utils.LeaderElectionRetryPeriodContainerArg(leaderElectionSpec.RetryPeriod),
 		}
 
+		// TODO: Move the Topology field from NodePlugin to Driver.Spec
+		nodePluginSpec := cmp.Or(r.driver.Spec.NodePlugin, &csiv1a1.NodePluginSpec{})
+		topology := r.isRdbDriver() && nodePluginSpec.Topology != nil
+
 		deploy.Spec = appsv1.DeploymentSpec{
 			Replicas: pluginSpec.Replicas,
 			Selector: &appSelector,
@@ -662,7 +666,7 @@ func (r *driverReconcile) reconcileControllerPluginDeployment() error {
 										utils.PreventVolumeModeConversionContainerArg,
 										utils.HonorPVReclaimPolicyContainerArg,
 										utils.If(r.isRdbDriver(), utils.DefaultFsTypeContainerArg, ""),
-										utils.If(r.isRdbDriver(), utils.ImmediateTopologyContainerArg, ""),
+										utils.TopologyContainerArg(topology),
 										utils.If(!r.isNfsDriver(), utils.ExtraCreateMetadataContainerArg, ""),
 									),
 								),

--- a/internal/utils/csi.go
+++ b/internal/utils/csi.go
@@ -395,7 +395,6 @@ var PoolTimeContainerArg = "--polltime=60s"
 var ExtraCreateMetadataContainerArg = "--extra-create-metadata=true"
 var PreventVolumeModeConversionContainerArg = "--prevent-volume-mode-conversion=true"
 var HonorPVReclaimPolicyContainerArg = "--feature-gates=HonorPVReclaimPolicy=true"
-var ImmediateTopologyContainerArg = "--immediate-topology=false"
 var RecoverVolumeExpansionFailureContainerArg = "--feature-gates=RecoverVolumeExpansionFailure=true"
 var EnableVolumeGroupSnapshotsContainerArg = "--feature-gates=CSIVolumeGroupSnapshot=true"
 var ForceCephKernelClientContainerArg = "--forcecephkernelclient=true"
@@ -472,4 +471,7 @@ func DomainLabelsContainerArg(options []string) string {
 		fmt.Sprintf("--domainlabels=%s", strings.Join(options, ",")),
 		"",
 	)
+}
+func TopologyContainerArg(topology bool) string {
+	return fmt.Sprintf("--feature-gates=Topology=%t", topology)
 }


### PR DESCRIPTION
If the admin sets the domain label in the nodeplugin we need to set the topology featuregate to true
in the controller deployment as the feature needs to be enabled on the both provisioner and the nodeplugin , If the domain labels are not set we need to disable the toplogy as its enabled by default.

