### PR TITLE
Deploy csi-addons sidecar with pod network

### DIFF
--- a/internal/controller/driver_controller.go
+++ b/internal/controller/driver_controller.go
@@ -229,16 +229,23 @@ func (r *driverReconcile) reconcile() error {
 		return err
 	}
 
-	// Concurrently reconcile different aspects of the clusters actual state to meet
-	// the desired state defined on the driver object
-	errChan := utils.RunConcurrently(
+	reconcilers := []func() error{
 		r.reconcileCsiConfigMap,
 		r.reconcileLogRotateConfigMap,
 		r.reconcileK8sCsiDriver,
 		r.reconcileControllerPluginDeployment,
 		r.reconcileNodePluginDeamonSet,
 		r.reconcileLivenessService,
-	)
+	}
+
+	// Deploy csi-addons sidecar in its own daemon set which doesn't use host network
+	if r.isRdbDriver() && ptr.Deref(r.driver.Spec.DeployCsiAddons, false) {
+		reconcilers = append(reconcilers, r.reconcileNodePluginDeamonSetForCsiAddons)
+	}
+
+	// Concurrently reconcile different aspects of the clusters actual state to meet
+	// the desired state defined on the driver object
+	errChan := utils.RunConcurrently(reconcilers...)
 
 	// Check if any reconcilatin error where raised during the concurrent execution
 	// of the reconciliation steps.
@@ -971,6 +978,195 @@ func (r *driverReconcile) controllerPluginCsiAddonsContainerPort() corev1.Contai
 
 }
 
+func (r *driverReconcile) reconcileNodePluginDeamonSetForCsiAddons() error {
+	daemonSet := &appsv1.DaemonSet{}
+	daemonSet.Name = r.generateName("nodeplugin-csi-addons")
+	daemonSet.Namespace = r.driver.Namespace
+
+	log := r.log.WithValues("csiAddonsDaemonSetName", daemonSet.Name)
+	log.Info("Reconciling csi addons nodeplugin deployment")
+
+	opResult, err := ctrlutil.CreateOrUpdate(r.ctx, r.Client, daemonSet, func() error {
+		if err := ctrlutil.SetControllerReference(&r.driver, daemonSet, r.Scheme); err != nil {
+			log.Error(err, "Failed to set owner reference on csi addons nodeplugin deployment")
+
+			return err
+		}
+
+		appName := daemonSet.Name
+		pluginSpec := cmp.Or(r.driver.Spec.NodePlugin, &csiv1.NodePluginSpec{})
+		serviceAccountName := cmp.Or(
+			ptr.Deref(pluginSpec.ServiceAccountName, ""),
+			fmt.Sprintf("%s%s-nodeplugin-sa", serviceAccountPrefix, r.driverType),
+		)
+		imagePullPolicy := cmp.Or(pluginSpec.ImagePullPolicy, corev1.PullIfNotPresent)
+		logVerbosity := ptr.Deref(r.driver.Spec.Log, csiv1.LogSpec{}).Verbosity
+		kubeletDirPath := cmp.Or(pluginSpec.KubeletDirPath, defaultKubeletDirPath)
+		port := utils.NodePluginCsiAddonsContainerPort
+
+		logRotationSpec := cmp.Or(r.driver.Spec.Log, &csiv1.LogSpec{}).Rotation
+		logRotationEnabled := logRotationSpec != nil
+
+		daemonSet.Spec = appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": appName},
+			},
+			UpdateStrategy: ptr.Deref(pluginSpec.UpdateStrategy, defaultDaemonSetUpdateStrategy),
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: utils.Call(func() map[string]string {
+						podLabels := map[string]string{}
+						maps.Copy(podLabels, pluginSpec.Labels)
+						podLabels["app"] = appName
+						if r.driver.Spec.Liveness != nil {
+							podLabels["contains"] = fmt.Sprintf("%s-metrics", appName)
+						}
+						return podLabels
+					}),
+					Annotations: maps.Clone(pluginSpec.Annotations),
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName: serviceAccountName,
+					PriorityClassName:  ptr.Deref(pluginSpec.PrioritylClassName, ""),
+					HostPID:            r.isRdbDriver(),
+					// to use e.g. Rook orchestrated cluster, and mons' FQDN is
+					// resolved through k8s service, set dns policy to cluster first
+					DNSPolicy:   corev1.DNSClusterFirstWithHostNet,
+					Tolerations: pluginSpec.Tolerations,
+					Containers: utils.Call(func() []corev1.Container {
+						containers := []corev1.Container{
+							{
+								Name:            "csi-addons",
+								Image:           r.images["addons"],
+								ImagePullPolicy: imagePullPolicy,
+								SecurityContext: &corev1.SecurityContext{
+									Privileged: ptr.To(true),
+									Capabilities: &corev1.Capabilities{
+										Drop: []corev1.Capability{"All"},
+									},
+								},
+								Args: utils.DeleteZeroValues(
+									[]string{
+										utils.CsiAddonsNodeIdContainerArg,
+										utils.LogVerbosityContainerArg(logVerbosity),
+										utils.CsiAddonsAddressContainerArg,
+										utils.ContainerPortArg(port),
+										utils.PodContainerArg,
+										utils.NamespaceContainerArg,
+										utils.PodUidContainerArg,
+										utils.StagingPathContainerArg(kubeletDirPath),
+										utils.If(logRotationEnabled, utils.LogToStdErrContainerArg, ""),
+										utils.If(logRotationEnabled, utils.AlsoLogToStdErrContainerArg, ""),
+										utils.If(logRotationEnabled, utils.LogFileContainerArg("csi-addons"), ""),
+									},
+								),
+								Ports: []corev1.ContainerPort{
+									port,
+								},
+								Env: []corev1.EnvVar{
+									utils.NodeIdEnvVar,
+									utils.PodNameEnvVar,
+									utils.PodNamespaceEnvVar,
+									utils.PodUidEnvVar,
+								},
+								VolumeMounts: utils.Call(func() []corev1.VolumeMount {
+									mounts := []corev1.VolumeMount{
+										utils.PluginDirVolumeMount,
+									}
+									if logRotationEnabled {
+										mounts = append(mounts, utils.LogsDirVolumeMount)
+									}
+									return mounts
+								}),
+								Resources: ptr.Deref(
+									pluginSpec.Resources.Addons,
+									corev1.ResourceRequirements{},
+								),
+							},
+						}
+						// Liveness Sidecar Container
+						if r.driver.Spec.Liveness != nil {
+							containers = append(containers, corev1.Container{
+								Name:            "liveness-prometheus",
+								Image:           r.images["plugin"],
+								ImagePullPolicy: imagePullPolicy,
+								SecurityContext: &corev1.SecurityContext{
+									Privileged: ptr.To(true),
+									Capabilities: &corev1.Capabilities{
+										Drop: []corev1.Capability{"All"},
+									},
+								},
+								Args: utils.DeleteZeroValues(
+									[]string{
+										utils.TypeContainerArg("liveness"),
+										utils.EndpointContainerArg,
+										utils.MetricsPortContainerArg(r.driver.Spec.Liveness.MetricsPort),
+										utils.MetricsPathContainerArg,
+										utils.PoolTimeContainerArg,
+										utils.TimeoutContainerArg(3),
+									},
+								),
+								Env: []corev1.EnvVar{
+									utils.PodIpEnvVar,
+								},
+								VolumeMounts: []corev1.VolumeMount{
+									utils.PluginDirVolumeMount,
+								},
+								Resources: ptr.Deref(
+									pluginSpec.Resources.Liveness,
+									corev1.ResourceRequirements{},
+								),
+							})
+						}
+						// CSI LogRotate Container
+						if logRotationEnabled {
+							resources := ptr.Deref(pluginSpec.Resources.LogRotator, corev1.ResourceRequirements{})
+							containers = append(containers, corev1.Container{
+								Name:            "log-rotator",
+								Image:           r.images["plugin"],
+								ImagePullPolicy: imagePullPolicy,
+								Resources:       resources,
+								SecurityContext: &corev1.SecurityContext{
+									Privileged: ptr.To(true),
+									Capabilities: &corev1.Capabilities{
+										Drop: []corev1.Capability{"All"},
+									},
+								},
+								Command: []string{"/bin/bash", "-c", logRotateCmd},
+								VolumeMounts: []corev1.VolumeMount{
+									utils.LogsDirVolumeMount,
+									utils.LogRotateDirVolumeMount,
+								},
+							})
+						}
+						return containers
+					}),
+					Volumes: utils.Call(func() []corev1.Volume {
+						volumes := []corev1.Volume{
+							utils.PluginDirVolume(kubeletDirPath, r.driver.Name),
+						}
+
+						if logRotationEnabled {
+							logHostPath := cmp.Or(logRotationSpec.LogHostPath, defaultLogHostPath)
+							volumes = append(
+								volumes,
+								utils.LogsDirVolume(logHostPath, daemonSet.Name),
+								utils.LogRotateDirVolumeName(r.driver.Name),
+							)
+						}
+						return volumes
+					}),
+				},
+			},
+		}
+
+		return nil
+	})
+
+	logCreateOrUpdateResult(log, "csi addons node plugin daemonset", daemonSet, opResult, err)
+	return err
+}
+
 func (r *driverReconcile) reconcileNodePluginDeamonSet() error {
 	daemonSet := &appsv1.DaemonSet{}
 	daemonSet.Name = r.generateName("nodeplugin")
@@ -1156,92 +1352,6 @@ func (r *driverReconcile) reconcileNodePluginDeamonSet() error {
 									corev1.ResourceRequirements{},
 								),
 							},
-						}
-						// CSI Addons Sidecar Container
-						if r.isRdbDriver() && ptr.Deref(r.driver.Spec.DeployCsiAddons, false) {
-							port := utils.NodePluginCsiAddonsContainerPort
-							containers = append(containers, corev1.Container{
-								Name:            "csi-addons",
-								Image:           r.images["addons"],
-								ImagePullPolicy: imagePullPolicy,
-								SecurityContext: &corev1.SecurityContext{
-									Privileged: ptr.To(true),
-									Capabilities: &corev1.Capabilities{
-										Drop: []corev1.Capability{"All"},
-									},
-								},
-								Args: utils.DeleteZeroValues(
-									[]string{
-										utils.CsiAddonsNodeIdContainerArg,
-										utils.LogVerbosityContainerArg(logVerbosity),
-										utils.CsiAddonsAddressContainerArg,
-										utils.ContainerPortArg(port),
-										utils.PodContainerArg,
-										utils.NamespaceContainerArg,
-										utils.PodUidContainerArg,
-										utils.StagingPathContainerArg(kubeletDirPath),
-										utils.If(logRotationEnabled, utils.LogToStdErrContainerArg, ""),
-										utils.If(logRotationEnabled, utils.AlsoLogToStdErrContainerArg, ""),
-										utils.If(logRotationEnabled, utils.LogFileContainerArg("csi-addons"), ""),
-									},
-								),
-								Ports: []corev1.ContainerPort{
-									port,
-								},
-								Env: []corev1.EnvVar{
-									utils.NodeIdEnvVar,
-									utils.PodNameEnvVar,
-									utils.PodNamespaceEnvVar,
-									utils.PodUidEnvVar,
-								},
-								VolumeMounts: utils.Call(func() []corev1.VolumeMount {
-									mounts := []corev1.VolumeMount{
-										utils.PluginDirVolumeMount,
-									}
-									if logRotationEnabled {
-										mounts = append(mounts, utils.LogsDirVolumeMount)
-									}
-									return mounts
-								}),
-								Resources: ptr.Deref(
-									pluginSpec.Resources.Addons,
-									corev1.ResourceRequirements{},
-								),
-							})
-							// Liveness Sidecar Container
-							if r.driver.Spec.Liveness != nil {
-								containers = append(containers, corev1.Container{
-									Name:            "liveness-prometheus",
-									Image:           r.images["plugin"],
-									ImagePullPolicy: imagePullPolicy,
-									SecurityContext: &corev1.SecurityContext{
-										Privileged: ptr.To(true),
-										Capabilities: &corev1.Capabilities{
-											Drop: []corev1.Capability{"All"},
-										},
-									},
-									Args: utils.DeleteZeroValues(
-										[]string{
-											utils.TypeContainerArg("liveness"),
-											utils.EndpointContainerArg,
-											utils.MetricsPortContainerArg(r.driver.Spec.Liveness.MetricsPort),
-											utils.MetricsPathContainerArg,
-											utils.PoolTimeContainerArg,
-											utils.TimeoutContainerArg(3),
-										},
-									),
-									Env: []corev1.EnvVar{
-										utils.PodIpEnvVar,
-									},
-									VolumeMounts: []corev1.VolumeMount{
-										utils.PluginDirVolumeMount,
-									},
-									Resources: ptr.Deref(
-										pluginSpec.Resources.Liveness,
-										corev1.ResourceRequirements{},
-									),
-								})
-							}
 						}
 						// CSI LogRotate Container
 						if logRotationEnabled {

--- a/internal/controller/driver_controller.go
+++ b/internal/controller/driver_controller.go
@@ -633,7 +633,7 @@ func (r *driverReconcile) reconcileControllerPluginDeployment() error {
 												return v.Mount
 											},
 										),
-										utils.SocketDirVolumeMount,
+										utils.PluginDirHostVolumeMount,
 										utils.HostDevVolumeMount,
 										utils.HostSysVolumeMount,
 										utils.LibModulesVolumeMount,
@@ -678,7 +678,7 @@ func (r *driverReconcile) reconcileControllerPluginDeployment() error {
 									),
 								),
 								VolumeMounts: []corev1.VolumeMount{
-									utils.SocketDirVolumeMount,
+									utils.PluginDirHostVolumeMount,
 								},
 								Resources: ptr.Deref(
 									pluginSpec.Resources.Provisioner,
@@ -702,7 +702,7 @@ func (r *driverReconcile) reconcileControllerPluginDeployment() error {
 									),
 								),
 								VolumeMounts: []corev1.VolumeMount{
-									utils.SocketDirVolumeMount,
+									utils.PluginDirHostVolumeMount,
 								},
 								Resources: ptr.Deref(
 									pluginSpec.Resources.Resizer,
@@ -725,7 +725,7 @@ func (r *driverReconcile) reconcileControllerPluginDeployment() error {
 									),
 								),
 								VolumeMounts: []corev1.VolumeMount{
-									utils.SocketDirVolumeMount,
+									utils.PluginDirHostVolumeMount,
 								},
 								Resources: ptr.Deref(
 									pluginSpec.Resources.Attacher,
@@ -755,7 +755,7 @@ func (r *driverReconcile) reconcileControllerPluginDeployment() error {
 									),
 								),
 								VolumeMounts: []corev1.VolumeMount{
-									utils.SocketDirVolumeMount,
+									utils.PluginDirHostVolumeMount,
 								},
 								Resources: ptr.Deref(
 									pluginSpec.Resources.Snapshotter,
@@ -790,7 +790,7 @@ func (r *driverReconcile) reconcileControllerPluginDeployment() error {
 									),
 								),
 								VolumeMounts: []corev1.VolumeMount{
-									utils.SocketDirVolumeMount,
+									utils.PluginDirHostVolumeMount,
 								},
 								Resources: ptr.Deref(
 									pluginSpec.Resources.Snapshotter,
@@ -832,7 +832,7 @@ func (r *driverReconcile) reconcileControllerPluginDeployment() error {
 								},
 								VolumeMounts: utils.Call(func() []corev1.VolumeMount {
 									mounts := []corev1.VolumeMount{
-										utils.SocketDirVolumeMount,
+										utils.PluginDirHostVolumeMount,
 									}
 									if logRotationEnabled {
 										mounts = append(mounts, utils.LogsDirVolumeMount)
@@ -894,7 +894,7 @@ func (r *driverReconcile) reconcileControllerPluginDeployment() error {
 									utils.PodIpEnvVar,
 								},
 								VolumeMounts: []corev1.VolumeMount{
-									utils.SocketDirVolumeMount,
+									utils.PluginDirHostVolumeMount,
 								},
 								Resources: ptr.Deref(
 									pluginSpec.Resources.Liveness,
@@ -933,7 +933,7 @@ func (r *driverReconcile) reconcileControllerPluginDeployment() error {
 							utils.HostDevVolume,
 							utils.HostSysVolume,
 							utils.LibModulesVolume,
-							utils.SocketDirVolume,
+							utils.PluginDirHostVolume(defaultKubeletDirPath, r.driver.Name),
 							utils.KeysTmpDirVolume,
 							utils.OidcTokenVolume,
 							utils.CsiConfigVolume,

--- a/internal/utils/csi.go
+++ b/internal/utils/csi.go
@@ -33,6 +33,7 @@ const (
 	csiMountInfoVolumeName   = "ceph-csi-mountinfo"
 	registrationVolumeName   = "registration-dir"
 	pluginDirVolumeName      = "plugin-dir"
+	pluginDirHostVolumeName  = "host-plugin-dir"
 	podsMountDirVolumeName   = "pods-mount-dir"
 	pluginMountDirVolumeName = "plugin-mount-dir"
 
@@ -44,14 +45,6 @@ const (
 )
 
 // Ceph CSI common volumes
-var SocketDirVolume = corev1.Volume{
-	Name: "socket-dir",
-	VolumeSource: corev1.VolumeSource{
-		EmptyDir: &corev1.EmptyDirVolumeSource{
-			Medium: corev1.StorageMediumMemory,
-		},
-	},
-}
 var HostDevVolume = corev1.Volume{
 	Name: "host-dev",
 	VolumeSource: corev1.VolumeSource{
@@ -165,6 +158,17 @@ func PluginMountDirVolume(kubeletDirPath string) corev1.Volume {
 		},
 	}
 }
+func PluginDirHostVolume(kubeletDirPath string, driverNamePrefix string) corev1.Volume {
+	return corev1.Volume{
+		Name: pluginDirHostVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: fmt.Sprintf("%s/plugins/%s/provisioner", kubeletDirPath, driverNamePrefix),
+				Type: ptr.To(corev1.HostPathDirectoryOrCreate),
+			},
+		},
+	}
+}
 func PluginDirVolume(kubeletDirPath string, driverNamePrefix string) corev1.Volume {
 	return corev1.Volume{
 		Name: pluginDirVolumeName,
@@ -223,10 +227,6 @@ func LogRotateDirVolumeName(driverName string) corev1.Volume {
 }
 
 // Ceph CSI common volume Mounts
-var SocketDirVolumeMount = corev1.VolumeMount{
-	Name:      SocketDirVolume.Name,
-	MountPath: SocketDir,
-}
 var HostDevVolumeMount = corev1.VolumeMount{
 	Name:      HostDevVolume.Name,
 	MountPath: "/dev",
@@ -268,6 +268,10 @@ var KmsConfigVolumeMount = corev1.VolumeMount{
 }
 var PluginDirVolumeMount = corev1.VolumeMount{
 	Name:      pluginDirVolumeName,
+	MountPath: "/csi",
+}
+var PluginDirHostVolumeMount = corev1.VolumeMount{
+	Name:      pluginDirHostVolumeName,
 	MountPath: "/csi",
 }
 var RegistrationDirVolumeMount = corev1.VolumeMount{

--- a/internal/utils/csi.go
+++ b/internal/utils/csi.go
@@ -163,7 +163,7 @@ func PluginDirHostVolume(kubeletDirPath string, driverNamePrefix string) corev1.
 		Name: pluginDirHostVolumeName,
 		VolumeSource: corev1.VolumeSource{
 			HostPath: &corev1.HostPathVolumeSource{
-				Path: fmt.Sprintf("%s/plugins/%s/provisioner", kubeletDirPath, driverNamePrefix),
+				Path: fmt.Sprintf("%s/plugins/%s/ctrl-plugin", kubeletDirPath, driverNamePrefix),
 				Type: ptr.To(corev1.HostPathDirectoryOrCreate),
 			},
 		},

--- a/internal/utils/ctrl.go
+++ b/internal/utils/ctrl.go
@@ -1,0 +1,116 @@
+package utils
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var log logr.Logger
+
+const (
+	CSIAddonsDeploymentLabel     = "csi-addons-driver-type"
+	CSICtrlpluginDeploymentLabel = "csi-ctrlplugin-driver-type"
+)
+
+// AddNodeNameIndexerForPods adds a field indexer on manager for pods identified
+// by their nodeName
+func AddNodeNameIndexerForPods(mgr ctrl.Manager) error {
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &corev1.Pod{}, "spec.nodeName", func(rawObj client.Object) []string {
+		pod, ok := rawObj.(*corev1.Pod)
+		if !ok {
+			return nil
+		}
+
+		if pod.Spec.NodeName == "" {
+			return nil
+		}
+		return []string{pod.Spec.NodeName}
+	}); err != nil {
+		log.Error(err, "failed to set field indexer for pods on manager")
+		return err
+	}
+
+	log.Info("Successfully set node name indexer for pods on manager")
+	return nil
+}
+
+// AddEventHandlerForPodDeletion watches for pod delete events.
+// If the deleted pod is of csi ctrlplugin deployment the matching
+// csi-addons deployment pod is deleted so that the scheduler could reevaluate
+// pod placement
+func AddEventHandlerForPodDeletion(c client.Client, mgr ctrl.Manager) error {
+	podInformer, err := mgr.GetCache().GetInformer(context.Background(), &corev1.Pod{})
+	if err != nil {
+		log.Error(err, "failed to fetch informer for pods from manager")
+		return err
+	}
+
+	if _, err = podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		DeleteFunc: func(obj any) {
+			pod, ok := obj.(*corev1.Pod)
+			if !ok {
+				return
+			}
+
+			driverType, found := pod.GetLabels()[CSICtrlpluginDeploymentLabel]
+			if !found {
+				return
+			}
+
+			log.Info("Encountered a delete event for csi ctrlplugin pod", "PodName", pod.GetName(), "NodeName", pod.Spec.NodeName, "DriverType", driverType)
+			csiAddonsPodSelector := labels.SelectorFromSet(labels.Set{
+				CSIAddonsDeploymentLabel: driverType,
+			})
+
+			listOpts := []client.ListOption{
+				client.InNamespace(pod.GetNamespace()),
+				client.MatchingLabelsSelector{Selector: csiAddonsPodSelector},
+				client.MatchingFields{"spec.nodeName": pod.Spec.NodeName},
+			}
+
+			ctx := context.Background()
+			podList := &corev1.PodList{}
+			if err := c.List(ctx, podList, listOpts...); err != nil {
+				log.Error(err, "failed to list pods with requested list options", "ListOptions", listOpts)
+				return
+			}
+
+			podsLen := len(podList.Items)
+			if podsLen == 0 || podsLen > 1 {
+				log.Info("found unexpected number of pods with requested list options", "ListOptions", listOpts, "NumberOfPods", podsLen)
+				return
+			}
+
+			for _, podToDelete := range podList.Items {
+				if err := c.Delete(ctx, &podToDelete); client.IgnoreNotFound(err) != nil {
+					log.Error(err, "failed to delete orphan csi-addons pod", "PodName", podToDelete.GetName())
+					return
+				}
+
+				log.Info("Successfully removed orphaned csi-addons pod", "PodName", podToDelete.GetName(), "NodeName", podToDelete.Spec.NodeName)
+			}
+
+		},
+	}); err != nil {
+		log.Error(err, "failed to add event handler on pod informer")
+		return err
+	}
+
+	log.Info("Successfully registered event handler for pod deletion events")
+	return nil
+}
+
+// The functions defined in this file will be used before a logger
+// is set on the reconciler, typically inside SetupWithManager.
+// Set a logger identified by "ctrl-utils" on init
+func init() {
+	log = ctrl.Log.WithName("ctrl-utils")
+}


### PR DESCRIPTION
This patch introduces a set of changes that allows the csi-addons sidecars to run without host networking. Here's a brief of the changes (separated into their own commits):

- Create a new DaemonSet for csi-addons sidecar that communicates with CSI nodeplugin.
  - The UDS is already on a hostpath which is shared across these two daemon sets.
- Modify the provisioner deployments to use hostpath for UDS located at:`kubelet_dir/plugin/driverid/ctrl-plugin`
- Create a separate deployment for CSI Addons to pair with provisioner deployments
  - The csi-addons to provisioner pairing is ensured using pod affinities.
