### PR TITLE
Fix: Use available images for testing

### DIFF
--- a/.github/workflows/test-chart.yml
+++ b/.github/workflows/test-chart.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Prepare ceph-csi-operator
         run: |
-          make docker-build
+          IMAGE_TAG=test make docker-build
 
       - name: Install helm
         run: |
@@ -48,7 +48,7 @@ jobs:
 
       - name: Install operator helm chart
         run: |
-          helm install csi-operator ./deploy/charts/ceph-csi-operator --create-namespace --namespace ceph-csi-operator-system
+          helm install csi-operator ./deploy/charts/ceph-csi-operator --create-namespace --namespace ceph-csi-operator-system --set controllerManager.manager.image.tag=test
 
       - name: Check operator helm release status
         run: |

--- a/internal/controller/defaults.go
+++ b/internal/controller/defaults.go
@@ -30,9 +30,9 @@ import (
 var imageDefaults = map[string]string{
 	"provisioner": "registry.k8s.io/sig-storage/csi-provisioner:v5.3.0",
 	"attacher":    "registry.k8s.io/sig-storage/csi-attacher:v4.9.0",
-	"resizer":     "registry.k8s.io/sig-storage/csi-resizer:v1.14.0",
+	"resizer":     "registry.k8s.io/sig-storage/csi-resizer:v1.13.2",
 	"snapshotter": "registry.k8s.io/sig-storage/csi-snapshotter:v8.2.0",
-	"registrar":   "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.1",
+	"registrar":   "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0",
 	"plugin":      "quay.io/cephcsi/cephcsi:v3.14.0",
 	"addons":      "quay.io/csiaddons/k8s-sidecar:v0.12.0",
 }


### PR DESCRIPTION
This PR includes below changes

* Use local built operator image for testing
* Use the available resizer and the node-registrar for testing (the new image still takes time to get push from kubernetes-csi )