### PR TITLE
helm: set appVersion in the helm charts

### DIFF
--- a/.github/workflows/publish-helm-charts.yaml
+++ b/.github/workflows/publish-helm-charts.yaml
@@ -43,8 +43,8 @@ jobs:
           echo "Packaging Helm charts..."
           mkdir -p .csi-op-release-packages
 
-          sed -i "s/^version:.*/version: ${VERSION}/" "deploy/charts/ceph-csi-operator/Chart.yaml"
-          sed -i "s/^version:.*/version: ${VERSION}/" "deploy/charts/ceph-csi-drivers/Chart.yaml"
+          sed -i "s/^version:.*/version: ${VERSION}/; s/^appVersion:.*/appVersion: v${VERSION}/" "deploy/charts/ceph-csi-operator/Chart.yaml"
+          sed -i "s/^version:.*/version: ${VERSION}/; s/^appVersion:.*/appVersion: v${VERSION}/" "deploy/charts/ceph-csi-drivers/Chart.yaml"
 
           helm package deploy/charts/ceph-csi-operator -d .csi-op-release-packages
           helm package deploy/charts/ceph-csi-drivers -d .csi-op-release-packages


### PR DESCRIPTION
For now we are only setting the version in the helm chart to install the specific version of it, There is another field in the
helm chart that represents the app version. Setting the appVersion similar to version to avoid confusion.

