### PR TITLE
ci: skip running operator tests

### DIFF
--- a/.github/workflows/test-charts.yaml
+++ b/.github/workflows/test-charts.yaml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
       - release-*
+    paths-ignore:
+      - 'docs/**' # ignore all the documents
+      - '*.md' # Ignore the Readme and PendingReleaseNote file
+      - '.*' # Ignore the config files
 
 # cancel the in-progress workflow when PR is refreshed.
 concurrency:

--- a/.github/workflows/test_operator.yaml
+++ b/.github/workflows/test_operator.yaml
@@ -4,6 +4,10 @@ on:
     branches:
       - main
       - release-*
+    paths-ignore:
+      - 'docs/**' # ignore all the documents
+      - '*.md' # Ignore the Readme and PendingReleaseNote file
+      - '.*' # Ignore the config files
 
 defaults:
   run:


### PR DESCRIPTION
if there is any change in the documentation or some config files that doesnt impact the operator or the csi driver, we dont run the github actions that will test the operator and the csi driver.

