### PR TITLE
api: add enable fencing flag

### DIFF
--- a/api/v1/driver_types.go
+++ b/api/v1/driver_types.go
@@ -297,6 +297,11 @@ type DriverSpec struct {
 	//+kubebuilder:validation:Optional
 	EnableMetadata *bool `json:"enableMetadata,omitempty"`
 
+	// Set to true to enable fencing for the driver.
+	// Fencing is a feature that allows the driver to fence a node when it is tainted with node.kubernetes.io/out-of-service.
+	//+kubebuilder:validation:Optional
+	EnableFencing *bool `json:"enableFencing,omitempty"`
+
 	// Set the gRPC timeout for gRPC call issued by the driver components
 	//+kubebuilder:validation:Optional
 	//+kubebuilder:validation:Minimum:=0

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -558,6 +558,11 @@ func (in *DriverSpec) DeepCopyInto(out *DriverSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.EnableFencing != nil {
+		in, out := &in.EnableFencing, &out.EnableFencing
+		*out = new(bool)
+		**out = **in
+	}
 	if in.GenerateOMapInfo != nil {
 		in, out := &in.GenerateOMapInfo, &out.GenerateOMapInfo
 		*out = new(bool)

--- a/config/crd/bases/csi.ceph.io_drivers.yaml
+++ b/config/crd/bases/csi.ceph.io_drivers.yaml
@@ -3527,6 +3527,11 @@ spec:
               deployCsiAddons:
                 description: a list of additional sidecars?
                 type: boolean
+              enableFencing:
+                description: |-
+                  Set to true to enable fencing for the driver.
+                  Fencing is a feature that allows the driver to fence a node when it is tainted with node.kubernetes.io/out-of-service.
+                type: boolean
               enableMetadata:
                 description: |-
                   Set to true to enable adding volume metadata on the CephFS subvolumes and RBD images.

--- a/config/crd/bases/csi.ceph.io_operatorconfigs.yaml
+++ b/config/crd/bases/csi.ceph.io_operatorconfigs.yaml
@@ -3565,6 +3565,11 @@ spec:
                   deployCsiAddons:
                     description: a list of additional sidecars?
                     type: boolean
+                  enableFencing:
+                    description: |-
+                      Set to true to enable fencing for the driver.
+                      Fencing is a feature that allows the driver to fence a node when it is tainted with node.kubernetes.io/out-of-service.
+                    type: boolean
                   enableMetadata:
                     description: |-
                       Set to true to enable adding volume metadata on the CephFS subvolumes and RBD images.

--- a/deploy/all-in-one/install.yaml
+++ b/deploy/all-in-one/install.yaml
@@ -4003,6 +4003,11 @@ spec:
               deployCsiAddons:
                 description: a list of additional sidecars?
                 type: boolean
+              enableFencing:
+                description: |-
+                  Set to true to enable fencing for the driver.
+                  Fencing is a feature that allows the driver to fence a node when it is tainted with node.kubernetes.io/out-of-service.
+                type: boolean
               enableMetadata:
                 description: |-
                   Set to true to enable adding volume metadata on the CephFS subvolumes and RBD images.
@@ -17910,6 +17915,11 @@ spec:
                     type: object
                   deployCsiAddons:
                     description: a list of additional sidecars?
+                    type: boolean
+                  enableFencing:
+                    description: |-
+                      Set to true to enable fencing for the driver.
+                      Fencing is a feature that allows the driver to fence a node when it is tainted with node.kubernetes.io/out-of-service.
                     type: boolean
                   enableMetadata:
                     description: |-

--- a/deploy/charts/ceph-csi-operator/templates/driver-crd.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/driver-crd.yaml
@@ -3524,6 +3524,11 @@ spec:
               deployCsiAddons:
                 description: a list of additional sidecars?
                 type: boolean
+              enableFencing:
+                description: |-
+                  Set to true to enable fencing for the driver.
+                  Fencing is a feature that allows the driver to fence a node when it is tainted with node.kubernetes.io/out-of-service.
+                type: boolean
               enableMetadata:
                 description: |-
                   Set to true to enable adding volume metadata on the CephFS subvolumes and RBD images.

--- a/deploy/charts/ceph-csi-operator/templates/operatorconfig-crd.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/operatorconfig-crd.yaml
@@ -3554,6 +3554,11 @@ spec:
                   deployCsiAddons:
                     description: a list of additional sidecars?
                     type: boolean
+                  enableFencing:
+                    description: |-
+                      Set to true to enable fencing for the driver.
+                      Fencing is a feature that allows the driver to fence a node when it is tainted with node.kubernetes.io/out-of-service.
+                    type: boolean
                   enableMetadata:
                     description: |-
                       Set to true to enable adding volume metadata on the CephFS subvolumes and RBD images.

--- a/deploy/multifile/crd.yaml
+++ b/deploy/multifile/crd.yaml
@@ -3994,6 +3994,11 @@ spec:
               deployCsiAddons:
                 description: a list of additional sidecars?
                 type: boolean
+              enableFencing:
+                description: |-
+                  Set to true to enable fencing for the driver.
+                  Fencing is a feature that allows the driver to fence a node when it is tainted with node.kubernetes.io/out-of-service.
+                type: boolean
               enableMetadata:
                 description: |-
                   Set to true to enable adding volume metadata on the CephFS subvolumes and RBD images.
@@ -17901,6 +17906,11 @@ spec:
                     type: object
                   deployCsiAddons:
                     description: a list of additional sidecars?
+                    type: boolean
+                  enableFencing:
+                    description: |-
+                      Set to true to enable fencing for the driver.
+                      Fencing is a feature that allows the driver to fence a node when it is tainted with node.kubernetes.io/out-of-service.
                     type: boolean
                   enableMetadata:
                     description: |-

--- a/internal/controller/driver_controller.go
+++ b/internal/controller/driver_controller.go
@@ -595,6 +595,7 @@ func (r *driverReconcile) reconcileControllerPluginDeployment() error {
 										utils.DriverNameContainerArg(r.driver.Name),
 										utils.PidlimitContainerArg,
 										utils.SetMetadataContainerArg(ptr.Deref(r.driver.Spec.EnableMetadata, false)),
+										utils.SetFencingContainerArg(ptr.Deref(r.driver.Spec.EnableFencing, false)),
 										utils.ClusterNameContainerArg(ptr.Deref(r.driver.Spec.ClusterName, "")),
 										utils.If(forceKernelClient, utils.ForceCephKernelClientContainerArg, ""),
 										utils.If(
@@ -1050,6 +1051,7 @@ func (r *driverReconcile) reconcileNodePluginDeamonSet() error {
 										utils.NodeServerContainerArg,
 										utils.NodeIdContainerArg,
 										utils.DriverNameContainerArg(r.driver.Name),
+										utils.SetFencingContainerArg(ptr.Deref(r.driver.Spec.EnableFencing, false)),
 										utils.EndpointContainerArg,
 										utils.PidlimitContainerArg,
 										utils.If(forceKernelClient, utils.ForceCephKernelClientContainerArg, ""),

--- a/internal/utils/csi.go
+++ b/internal/utils/csi.go
@@ -418,6 +418,9 @@ func TypeContainerArg(t string) string {
 func SetMetadataContainerArg(on bool) string {
 	return If(on, "--setmetadata=true", "")
 }
+func SetFencingContainerArg(on bool) string {
+	return If(on, "--enable-fencing=true", "")
+}
 func TimeoutContainerArg(timeout int) string {
 	return fmt.Sprintf("--timeout=%ds", timeout)
 }

--- a/vendor/github.com/ceph/ceph-csi-operator/api/v1/driver_types.go
+++ b/vendor/github.com/ceph/ceph-csi-operator/api/v1/driver_types.go
@@ -297,6 +297,11 @@ type DriverSpec struct {
 	//+kubebuilder:validation:Optional
 	EnableMetadata *bool `json:"enableMetadata,omitempty"`
 
+	// Set to true to enable fencing for the driver.
+	// Fencing is a feature that allows the driver to fence a node when it is tainted with node.kubernetes.io/out-of-service.
+	//+kubebuilder:validation:Optional
+	EnableFencing *bool `json:"enableFencing,omitempty"`
+
 	// Set the gRPC timeout for gRPC call issued by the driver components
 	//+kubebuilder:validation:Optional
 	//+kubebuilder:validation:Minimum:=0

--- a/vendor/github.com/ceph/ceph-csi-operator/api/v1/zz_generated.deepcopy.go
+++ b/vendor/github.com/ceph/ceph-csi-operator/api/v1/zz_generated.deepcopy.go
@@ -558,6 +558,11 @@ func (in *DriverSpec) DeepCopyInto(out *DriverSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.EnableFencing != nil {
+		in, out := &in.EnableFencing, &out.EnableFencing
+		*out = new(bool)
+		**out = **in
+	}
 	if in.GenerateOMapInfo != nil {
 		in, out := &in.GenerateOMapInfo, &out.GenerateOMapInfo
 		*out = new(bool)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi-operator! -->

# Describe what this PR does #

Ceph-CSI added `enable-fencing` flag in https://github.com/ceph/ceph-csi/pull/5429/commits/e77ce041a9ab5c9fa8903acbbfed0ae9a50a7e04
```
Introduce a new flag 'enable-fencing' false by default.
When enabled driver can set the client address per node in
the volume metadata during NodeStageVolume operation and
fence the node in ControllerUnpublishVolume and unfence
the node in ControllerPublishVolume using the address stored
in the volume metadata.
```

This PR adds the support for the same.

Ref:
- https://github.com/ceph/ceph-csi/pull/5429

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi operator/blob/main/docs/development-guide.md#development-workflow)
* [ ] [Pending release notes](https://github.com/ceph/ceph-csi-operator/blob/main/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.
