### PR TITLE
Deploy CSI-Addons with volume condition reporter

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -4,4 +4,6 @@
 
 ## Features
 
+- CSI-Addons Volume Condition reporting can be enabled by annotating a Driver with `addons.csi.ceph.io/volume-condition: true`.
+
 ## NOTE

--- a/config/csi-rbac/cephfs_nodeplugin_cluster_role.yaml
+++ b/config/csi-rbac/cephfs_nodeplugin_cluster_role.yaml
@@ -19,3 +19,10 @@ rules:
 - apiGroups: [""]
   resources: ["serviceaccounts/token"]
   verbs: ["create"]
+# events and pv, pvc for volume condition reporter
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["list", "watch", "create", "update", "patch"]
+- apiGroups: [""]
+  resources: ["persistentvolumes", "persistentvolumeclaims"]
+  verbs: ["get"]

--- a/config/csi-rbac/cephfs_nodeplugin_role.yaml
+++ b/config/csi-rbac/cephfs_nodeplugin_role.yaml
@@ -1,0 +1,17 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cephfs-nodeplugin-r
+rules:
+  - apiGroups: ["csiaddons.openshift.io"]
+    resources: ["csiaddonsnodes"]
+    verbs: ["get", "watch", "list", "create", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["deployments/finalizers", "daemonsets/finalizers"]
+    verbs: ["update"]

--- a/config/csi-rbac/cephfs_nodeplugin_role_binding.yaml
+++ b/config/csi-rbac/cephfs_nodeplugin_role_binding.yaml
@@ -1,0 +1,12 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cephfs-nodeplugin-rb
+subjects:
+  - kind: ServiceAccount
+    name: cephfs-nodeplugin-sa
+    namespace: system
+roleRef:
+  kind: Role
+  name: cephfs-nodeplugin-r
+  apiGroup: rbac.authorization.k8s.io

--- a/config/csi-rbac/rbd_nodeplugin_cluster_role.yaml
+++ b/config/csi-rbac/rbd_nodeplugin_cluster_role.yaml
@@ -27,3 +27,10 @@ rules:
   - apiGroups: ["authentication.k8s.io"]
     resources: ["tokenreviews"]
     verbs: ["create"]
+# events and pvc for volume condition reporter
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get"]

--- a/deploy/all-in-one/install.yaml
+++ b/deploy/all-in-one/install.yaml
@@ -28869,6 +28869,23 @@ rules:
   - serviceaccounts/token
   verbs:
   - create
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  - persistentvolumeclaims
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -29612,6 +29629,22 @@ rules:
   - tokenreviews
   verbs:
   - create
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/deploy/charts/ceph-csi-operator/templates/cephfs-nodeplugin-cr-rbac.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/cephfs-nodeplugin-cr-rbac.yaml
@@ -35,3 +35,20 @@ rules:
   - serviceaccounts/token
   verbs:
   - create
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  - persistentvolumeclaims
+  verbs:
+  - get

--- a/deploy/charts/ceph-csi-operator/templates/rbd-nodeplugin-cr-rbac.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/rbd-nodeplugin-cr-rbac.yaml
@@ -56,3 +56,19 @@ rules:
   - tokenreviews
   verbs:
   - create
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get

--- a/deploy/multifile/csi-rbac.yaml
+++ b/deploy/multifile/csi-rbac.yaml
@@ -398,6 +398,23 @@ rules:
   - serviceaccounts/token
   verbs:
   - create
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  - persistentvolumeclaims
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -813,6 +830,22 @@ rules:
   - tokenreviews
   verbs:
   - create
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/internal/utils/csi.go
+++ b/internal/utils/csi.go
@@ -400,6 +400,7 @@ var EnableVolumeGroupSnapshotsContainerArg = "--feature-gates=CSIVolumeGroupSnap
 var ForceCephKernelClientContainerArg = "--forcecephkernelclient=true"
 var LogToStdErrContainerArg = "--logtostderr=false"
 var AlsoLogToStdErrContainerArg = "--alsologtostderr=true"
+var CsiAddonsVolumeConditionArg = "--enable-volume-condition=true"
 
 func LogVerbosityContainerArg(level int) string {
 	return fmt.Sprintf("--v=%d", Clamp(level, 0, 5))


### PR DESCRIPTION
# Describe what this PR does #

When a Driver gets annotated with

    addons.csi.ceph.io/volume-condition: true

the CSI-Addons DaemonSet for that driver will get deployed with the extra `--enable-volume-condition=true` commandline flag. This causes the CSI-Addons sidecar to periodically check attached volumes for this Driver and report the condition in the logs of the sidecar and as an Event for the PersistentVolumeClaim.

## Is there anything that requires special attention ##

The volume condition reporter has been merged in csi-addons/kubernetes-csi-addons#831, but a release is still pending. That means the `--enable-volume-condition` commandline flag for the sidecar does not work without replacing the container-image with `quay.io/csiaddons/k8s-sidecar:latest`.

## Future concerns ##

- currently CSI-Addons for NFS is forcefully disabled, this should become optional too

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#development-workflow)
* [x] [Pending release
  notes](https://github.com/ceph/ceph-csi-operator/blob/main/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.
