### PR TITLE
doc: use csi.ceph.io/v1 instead of v1alpha1

### DIFF
--- a/docs/design/hostNetwork.md
+++ b/docs/design/hostNetwork.md
@@ -22,7 +22,7 @@ Example:
 
 ```yaml
 kind: OperatorConfig 
-apiVersion: csi.ceph.io/v1alpha1
+apiVersion: csi.ceph.io/v1
 metadata:
   name: ceph-csi-operator-config
   namespace: <operator-namespace>
@@ -34,7 +34,7 @@ spec:
 ## Driver CR
 
 ```yaml
-apiVersion: csi.ceph.io/v1alpha1
+apiVersion: csi.ceph.io/v1
 kind: Driver
 metadata:
   name: rbd.csi.ceph.com

--- a/docs/design/logrotate.md
+++ b/docs/design/logrotate.md
@@ -8,7 +8,7 @@ Logroate configuration,
 
 ```yaml
 kind: OperatorConfig 
-apiVersion: csi.ceph.io/v1alpha1
+apiVersion: csi.ceph.io/v1
 ….
 spec: 
     log:
@@ -28,7 +28,7 @@ Similar settings will be overridden by `Driver CRD`:
 
 ```yaml
 kind: Driver 
-apiVersion: csi.ceph.io/v1alpha1 
+apiVersion: csi.ceph.io/v1
 metadata: 
     name: "<prefix>.<driver_type>.csi.ceph.com" 
     namespace:  <operator-namespace> 

--- a/docs/design/operator.md
+++ b/docs/design/operator.md
@@ -78,7 +78,7 @@ The configurations are categorized into 2 different types
 ```yaml
 ---
 kind: OperatorConfig
-apiVersion: csi.ceph.io/v1alpha1
+apiVersion: csi.ceph.io/v1
 metadata:
   name: ceph-csi-operator-config
   namespace: <operator-namespace>
@@ -259,7 +259,7 @@ RBD, and NFS CSI drivers within namespaces.
 ```yaml
 ---
 kind: Driver
-apiVersion: csi.ceph.io/v1alpha1
+apiVersion: csi.ceph.io/v1
 metadata:
   name: "<prefix>.<driver_type>.csi.ceph.com"
   namespace: <operator-namespace>
@@ -311,7 +311,7 @@ provide the information to be used by multiple CSI drivers.
 ```yaml
 ---
 kind: CephConnection
-apiVersion: csi.ceph.io/v1alpha1
+apiVersion: csi.ceph.io/v1
 metadata:
   name: ceph-cluster-1
   namespace: <operator-namespace>
@@ -338,7 +338,7 @@ the connection information for the target Ceph cluster.
 ```yaml
 ---
 kind: ClientProfile
-apiVersion: csi.ceph.io/v1alpha1
+apiVersion: csi.ceph.io/v1
 metadata:
   name: storage
   namespace: <operator-namespace>

--- a/docs/kubernetes-installation.md
+++ b/docs/kubernetes-installation.md
@@ -135,7 +135,7 @@ Once the operator is installed, deploy the Ceph-CSI drivers:
 
 ```console
 echo '
-apiVersion: csi.ceph.io/v1alpha1
+apiVersion: csi.ceph.io/v1
 kind: Driver
 metadata:
   name: rbd.csi.ceph.com
@@ -147,7 +147,7 @@ metadata:
 
 ```console
 echo '
-apiVersion: csi.ceph.io/v1alpha1
+apiVersion: csi.ceph.io/v1
 kind: Driver
 metadata:
   name: cephfs.csi.ceph.com
@@ -159,7 +159,7 @@ metadata:
 
 ```console
 echo '
-apiVersion: csi.ceph.io/v1alpha1
+apiVersion: csi.ceph.io/v1
 kind: Driver
 metadata:
   name: nfs.csi.ceph.com
@@ -189,7 +189,7 @@ Create a CephConnection CR to connect to the Ceph cluster:
 
 ```console
 echo '
-apiVersion: csi.ceph.io/v1alpha1
+apiVersion: csi.ceph.io/v1
 kind: CephConnection
 metadata:
   name: ceph-connection
@@ -207,7 +207,7 @@ the CephConnection CR and the CephFS and RBD configurations:
 
 ```console
 echo '
-apiVersion: csi.ceph.io/v1alpha1
+apiVersion: csi.ceph.io/v1
 kind: ClientProfile
 metadata:
   name: storage

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -44,7 +44,7 @@ Once the operator is installed, deploy the Ceph-CSI drivers:
 
 ```console
 echo '
-apiVersion: csi.ceph.io/v1alpha1
+apiVersion: csi.ceph.io/v1
 kind: Driver
 metadata:
   name: rbd.csi.ceph.com
@@ -56,7 +56,7 @@ metadata:
 
 ```console
 echo '
-apiVersion: csi.ceph.io/v1alpha1
+apiVersion: csi.ceph.io/v1
 kind: Driver
 metadata:
   name: cephfs.csi.ceph.com
@@ -68,7 +68,7 @@ metadata:
 
 ```console
 echo '
-apiVersion: csi.ceph.io/v1alpha1
+apiVersion: csi.ceph.io/v1
 kind: Driver
 metadata:
   name: nfs.csi.ceph.com
@@ -98,7 +98,7 @@ Create a CephConnection CR to connect to the Ceph cluster:
 
 ```console
 echo '
-apiVersion: csi.ceph.io/v1alpha1
+apiVersion: csi.ceph.io/v1
 kind: CephConnection
 metadata:
   name: ceph-connection
@@ -116,7 +116,7 @@ the CephConnection CR and the CephFS and RBD configurations:
 
 ```console
 echo '
-apiVersion: csi.ceph.io/v1alpha1
+apiVersion: csi.ceph.io/v1
 kind: ClientProfile
 metadata:
   name: storage


### PR DESCRIPTION
The API moved to v1, but the quickstart and other documents still
referred to v1alpha1.