### PR TITLE
update Kubernetes CSI-Addons sidecar to v0.13.0

### DIFF
--- a/internal/controller/defaults.go
+++ b/internal/controller/defaults.go
@@ -35,7 +35,7 @@ var imageDefaults = map[string]string{
 	"registrar":         "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0",
 	"snapshot-metadata": "registry.k8s.io/sig-storage/csi-snapshot-metadata:v0.1.0",
 	"plugin":            "quay.io/cephcsi/cephcsi:v3.14.1",
-	"addons":            "quay.io/csiaddons/k8s-sidecar:v0.12.0",
+	"addons":            "quay.io/csiaddons/k8s-sidecar:v0.13.0",
 }
 
 const (


### PR DESCRIPTION
Kubernetes CSI-Addons 0.13.0 has been released today: https://github.com/csi-addons/kubernetes-csi-addons/releases/tag/v0.13.0 This release contains the Volume Condition Reporter that can be enabled by annotating the driver CR.

See-also: #282