### PR TITLE
csi: add snapshotmetadataservice crd existence check

### DIFF
--- a/internal/controller/driver_controller.go
+++ b/internal/controller/driver_controller.go
@@ -34,6 +34,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -232,7 +233,7 @@ func (r *DriverReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 func (r *driverReconcile) hasSnapshotMetadataServiceCr() (bool, error) {
 	sms := &sm.SnapshotMetadataService{}
 	sms.Name = r.driver.Name
-	if err := r.Get(r.ctx, client.ObjectKeyFromObject(sms), sms); client.IgnoreNotFound(err) != nil {
+	if err := r.Get(r.ctx, client.ObjectKeyFromObject(sms), sms); !meta.IsNoMatchError(err) && client.IgnoreNotFound(err) != nil {
 		return false, fmt.Errorf("failed to get SnapshotMetadataService resource: %w", err)
 	}
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi-operator! -->

# Describe what this PR does #

```
This commit adds a check for snapshotmetadataservice crd existence
before checking if the CR exists. This is done to avoid unwanted
error logs when the CRD is not present in the cluster.
```

Fixes: #297 

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#development-workflow)
* [ ] [Pending release notes](https://github.com/ceph/ceph-csi-operator/blob/main/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.
