### PR TITLE
support custom imagePullSecrets in all ServiceAccounts

### DIFF
--- a/deploy/charts/ceph-csi-drivers/templates/serviceaccount.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/serviceaccount.yaml
@@ -8,11 +8,23 @@ kind: ServiceAccount
 metadata:
   name: {{ $normalizedDriverName }}-ctrlplugin-sa
   namespace: {{ $root.Release.Namespace }}
+{{- if gt (len $root.Values.imagePullSecrets) 0 }}
+imagePullSecrets:
+{{- range $pullSecret := $root.Values.imagePullSecrets }}
+  - name: {{ $pullSecret }}
+{{- end }}
+{{- end }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ $normalizedDriverName }}-nodeplugin-sa
   namespace: {{ $root.Release.Namespace }}
+{{- if gt (len $root.Values.imagePullSecrets) 0 }}
+imagePullSecrets:
+{{- range $pullSecret := $root.Values.imagePullSecrets }}
+  - name: {{ $pullSecret }}
+{{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/deploy/charts/ceph-csi-drivers/values.yaml
+++ b/deploy/charts/ceph-csi-drivers/values.yaml
@@ -474,3 +474,6 @@ drivers:
 
       # List of tolerations for the controller plugin
       tolerations: []
+
+# List of pull secret names that will be added to all serviceaccounts
+imagePullSecrets: []

--- a/deploy/charts/ceph-csi-operator/templates/serviceaccount.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/serviceaccount.yaml
@@ -6,6 +6,12 @@ metadata:
   {{- include "ceph-csi-operator.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.cephfsCtrlpluginSa.serviceAccount.annotations | nindent 4 }}
+{{- if gt (len .Values.imagePullSecrets) 0 }}
+imagePullSecrets:
+{{- range $pullSecret := .Values.imagePullSecrets }}
+  - name: {{ $pullSecret }}
+{{- end }}
+{{- end }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -15,6 +21,12 @@ metadata:
   {{- include "ceph-csi-operator.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.cephfsNodepluginSa.serviceAccount.annotations | nindent 4 }}
+{{- if gt (len .Values.imagePullSecrets) 0 }}
+imagePullSecrets:
+{{- range $pullSecret := .Values.imagePullSecrets }}
+  - name: {{ $pullSecret }}
+{{- end }}
+{{- end }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -24,6 +36,12 @@ metadata:
   {{- include "ceph-csi-operator.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.controllerManager.serviceAccount.annotations | nindent 4 }}
+{{- if gt (len .Values.imagePullSecrets) 0 }}
+imagePullSecrets:
+{{- range $pullSecret := .Values.imagePullSecrets }}
+  - name: {{ $pullSecret }}
+{{- end }}
+{{- end }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -33,6 +51,12 @@ metadata:
   {{- include "ceph-csi-operator.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.nfsCtrlpluginSa.serviceAccount.annotations | nindent 4 }}
+{{- if gt (len .Values.imagePullSecrets) 0 }}
+imagePullSecrets:
+{{- range $pullSecret := .Values.imagePullSecrets }}
+  - name: {{ $pullSecret }}
+{{- end }}
+{{- end }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -42,6 +66,12 @@ metadata:
   {{- include "ceph-csi-operator.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.nfsNodepluginSa.serviceAccount.annotations | nindent 4 }}
+{{- if gt (len .Values.imagePullSecrets) 0 }}
+imagePullSecrets:
+{{- range $pullSecret := .Values.imagePullSecrets }}
+  - name: {{ $pullSecret }}
+{{- end }}
+{{- end }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -51,6 +81,12 @@ metadata:
   {{- include "ceph-csi-operator.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.rbdCtrlpluginSa.serviceAccount.annotations | nindent 4 }}
+{{- if gt (len .Values.imagePullSecrets) 0 }}
+imagePullSecrets:
+{{- range $pullSecret := .Values.imagePullSecrets }}
+  - name: {{ $pullSecret }}
+{{- end }}
+{{- end }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -60,3 +96,9 @@ metadata:
   {{- include "ceph-csi-operator.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.rbdNodepluginSa.serviceAccount.annotations | nindent 4 }}
+{{- if gt (len .Values.imagePullSecrets) 0 }}
+imagePullSecrets:
+{{- range $pullSecret := .Values.imagePullSecrets }}
+  - name: {{ $pullSecret }}
+{{- end }}
+{{- end }}

--- a/deploy/charts/ceph-csi-operator/values.yaml
+++ b/deploy/charts/ceph-csi-operator/values.yaml
@@ -45,3 +45,5 @@ rbdCtrlpluginSa:
 rbdNodepluginSa:
   serviceAccount:
     annotations: {}
+# List of pull secret names that will be added to all serviceaccounts
+imagePullSecrets: []

--- a/docs/helm-charts/drivers-chart.md
+++ b/docs/helm-charts/drivers-chart.md
@@ -156,6 +156,7 @@ The following table lists the configurable parameters of the ceph-csi-drivers ch
 | `drivers.rbd.nodePlugin.tolerations` |  | `[]` |
 | `drivers.rbd.nodePlugin.volumes` |  | `[]` |
 | `drivers.rbd.snapshotPolicy` |  | `"none"` |
+| `imagePullSecrets` |  | `[]` |
 | `operatorConfig.create` |  | `true` |
 | `operatorConfig.driverSpecDefaults.attachRequired` |  | `true` |
 | `operatorConfig.driverSpecDefaults.cephFsClientType` |  | `"kernel"` |


### PR DESCRIPTION
sample usage:
IMAGE_PULL_SECRETS="secret-1" make build-installer
helm template csi deploy/charts/ceph-csi-drivers --set 'imagePullSecrets={secret-1}'
helm template csi deploy/charts/ceph-csi-operator --set 'imagePullSecrets={secret-1}'

fixes: #305 
