### PR TITLE
rbac: include the role and rolebinding for CephFS nodeplugin

### DIFF
--- a/config/csi-rbac/kustomization.yaml
+++ b/config/csi-rbac/kustomization.yaml
@@ -9,6 +9,8 @@ resources:
 - cephfs_nodeplugin_service_account.yaml
 - cephfs_nodeplugin_cluster_role.yaml
 - cephfs_nodeplugin_cluster_role_binding.yaml
+- cephfs_nodeplugin_role.yaml
+- cephfs_nodeplugin_role_binding.yaml
 - nfs_ctrlplugin_cluster_role.yaml
 - nfs_ctrlplugin_cluster_role_binding.yaml
 - nfs_ctrlplugin_service_account.yaml

--- a/deploy/all-in-one/install.yaml
+++ b/deploy/all-in-one/install.yaml
@@ -28519,6 +28519,43 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  name: ceph-csi-operator-cephfs-nodeplugin-r
+  namespace: ceph-csi-operator-system
+rules:
+- apiGroups:
+  - csiaddons.openshift.io
+  resources:
+  - csiaddonsnodes
+  verbs:
+  - get
+  - watch
+  - list
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  - daemonsets/finalizers
+  verbs:
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
   labels:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: ceph-csi-operator
@@ -29733,6 +29770,20 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: ceph-csi-operator-cephfs-ctrlplugin-sa
+  namespace: ceph-csi-operator-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ceph-csi-operator-cephfs-nodeplugin-rb
+  namespace: ceph-csi-operator-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ceph-csi-operator-cephfs-nodeplugin-r
+subjects:
+- kind: ServiceAccount
+  name: ceph-csi-operator-cephfs-nodeplugin-sa
   namespace: ceph-csi-operator-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/charts/ceph-csi-drivers/templates/cephfs-nodeplugin-r-rbac.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/cephfs-nodeplugin-r-rbac.yaml
@@ -1,0 +1,46 @@
+{{- $root := . -}}
+{{- $driver := .Values.drivers.cephfs -}}
+{{- if $driver.enabled }}
+{{- $normalizedDriverName := include "normalizeDriverName" $driver.name }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $normalizedDriverName }}-nodeplugin-r
+rules:
+- apiGroups:
+  - csiaddons.openshift.io
+  resources:
+  - csiaddonsnodes
+  verbs:
+  - get
+  - watch
+  - list
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  - daemonsets/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+{{- end }}

--- a/deploy/charts/ceph-csi-drivers/templates/cephfs-nodeplugin-rb-rbac.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/cephfs-nodeplugin-rb-rbac.yaml
@@ -1,0 +1,17 @@
+{{- $root := . -}}
+{{- $driver := .Values.drivers.cephfs -}}
+{{- if $driver.enabled }}
+{{- $normalizedDriverName := include "normalizeDriverName" $driver.name }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $normalizedDriverName }}-nodeplugin-rb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $normalizedDriverName }}-nodeplugin-r
+subjects:
+- kind: ServiceAccount
+  name: {{ $normalizedDriverName }}-nodeplugin-sa
+  namespace: {{ $root.Release.Namespace }}
+{{- end }}

--- a/deploy/charts/ceph-csi-operator/templates/cephfs-nodeplugin-r-rbac.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/cephfs-nodeplugin-r-rbac.yaml
@@ -1,0 +1,37 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "ceph-csi-operator.fullname" . }}-cephfs-nodeplugin-r
+  labels:
+  {{- include "ceph-csi-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - csiaddons.openshift.io
+  resources:
+  - csiaddonsnodes
+  verbs:
+  - get
+  - watch
+  - list
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  - daemonsets/finalizers
+  verbs:
+  - update

--- a/deploy/charts/ceph-csi-operator/templates/cephfs-nodeplugin-rb-rbac.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/cephfs-nodeplugin-rb-rbac.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "ceph-csi-operator.fullname" . }}-cephfs-nodeplugin-rb
+  labels:
+  {{- include "ceph-csi-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: '{{ include "ceph-csi-operator.fullname" . }}-cephfs-nodeplugin-r'
+subjects:
+- kind: ServiceAccount
+  name: '{{ include "ceph-csi-operator.fullname" . }}-cephfs-nodeplugin-sa'
+  namespace: '{{ .Release.Namespace }}'

--- a/deploy/multifile/csi-rbac.yaml
+++ b/deploy/multifile/csi-rbac.yaml
@@ -85,6 +85,43 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  name: ceph-csi-operator-cephfs-nodeplugin-r
+  namespace: ceph-csi-operator-system
+rules:
+- apiGroups:
+  - csiaddons.openshift.io
+  resources:
+  - csiaddonsnodes
+  verbs:
+  - get
+  - watch
+  - list
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  - daemonsets/finalizers
+  verbs:
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
   name: ceph-csi-operator-rbd-ctrlplugin-r
   namespace: ceph-csi-operator-system
 rules:
@@ -872,6 +909,20 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: ceph-csi-operator-cephfs-ctrlplugin-sa
+  namespace: ceph-csi-operator-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ceph-csi-operator-cephfs-nodeplugin-rb
+  namespace: ceph-csi-operator-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ceph-csi-operator-cephfs-nodeplugin-r
+subjects:
+- kind: ServiceAccount
+  name: ceph-csi-operator-cephfs-nodeplugin-sa
   namespace: ceph-csi-operator-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
# Describe what this PR does #

Without the RBAC for accessing Pods and other resources, the CephFS nodeplugin can not successfully run the CSI-Addons sidecar/Pod.

## Related issues ##

The CSI-Addons Pod for CephFS fails to start:

```
$ oc -n openshift-storage logs openshift-storage.cephfs.csi.ceph.com-nodeplugin-csi-addongppcb
Defaulted container "csi-addons" out of: csi-addons, log-rotator
2025-09-05T15:14:02.434Z    INFO    Probing CSI driver for readiness
2025-09-05T15:14:02.436Z    DEBUG   Feature gate default state  {"feature": "ClientsPreferCBOR", "enabled": false}
2025-09-05T15:14:02.436Z    DEBUG   Feature gate default state  {"feature": "InformerResourceVersion", "enabled": false}
2025-09-05T15:14:02.436Z    DEBUG   Feature gate default state  {"feature": "InOrderInformers", "enabled": true}
2025-09-05T15:14:02.436Z    DEBUG   Feature gate default state  {"feature": "WatchListClient", "enabled": false}
2025-09-05T15:14:02.436Z    DEBUG   Feature gate default state  {"feature": "ClientsAllowCBOR", "enabled": false}
2025-09-05T15:14:02.437Z    INFO    The CSI-plugin does not have the CSI-Addons CONTROLLER_SERVICE capability, not running leader election
2025-09-05T15:14:02.631Z    INFO    failed to start watcher due to error: failed to get CSIAddonsNode object due to error: failed to get pod: pods "openshift-storage.cephfs.csi.ceph.com-nodeplugin-csi-addongppcb" is forbidden: User "system:serviceaccount:openshift-storage:ceph-csi-cephfs-nodeplugin-sa" cannot get resource "pods" in API group "" in the namespace "openshift-storage"
goroutine 98 [running]:
k8s.io/klog/v2/internal/dbg.Stacks(0x0)
    /src/remote_source/app/vendor/k8s.io/klog/v2/internal/dbg/dbg.go:35 +0x85
k8s.io/klog/v2.(*loggingT).output(0x377c480, 0x3, 0xc000310100, 0xc0002621c0, 0x1, {0x2b83045?, 0x1?}, 0x0?, 0x0)
    /src/remote_source/app/vendor/k8s.io/klog/v2/klog.go:944 +0x78a
k8s.io/klog/v2.(*loggingT).printfDepth(0x377c480, 0x3, 0xc000310100, {0x0, 0x0}, 0x1, {0x2207715, 0x28}, {0xc00041a290, 0x1, ...})
    /src/remote_source/app/vendor/k8s.io/klog/v2/klog.go:760 +0x1f0
k8s.io/klog/v2.(*loggingT).printf(...)
    /src/remote_source/app/vendor/k8s.io/klog/v2/klog.go:737
k8s.io/klog/v2.Fatalf(...)
    /src/remote_source/app/vendor/k8s.io/klog/v2/klog.go:1666
main.main.func1()
    /src/remote_source/app/sidecar/main.go:147 +0xc5
created by main.main in goroutine 1
    /src/remote_source/app/sidecar/main.go:144 +0xc26
```

**Checklist:**

* [*] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#commit-messages).
* [*] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi-operator/blob/main/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.
