### PR TITLE
driver: Change controller-plugin deployment strategy to Recreate

### DIFF
--- a/internal/controller/defaults.go
+++ b/internal/controller/defaults.go
@@ -59,11 +59,7 @@ var defaultDaemonSetUpdateStrategy = appsv1.DaemonSetUpdateStrategy{
 }
 
 var defaultDeploymentStrategy = appsv1.DeploymentStrategy{
-	Type: appsv1.RollingUpdateDeploymentStrategyType,
-	RollingUpdate: &appsv1.RollingUpdateDeployment{
-		MaxSurge:       ptr.To(intstr.FromString("25%")),
-		MaxUnavailable: ptr.To(intstr.FromString("25%")),
-	},
+	Type: appsv1.RecreateDeploymentStrategyType,
 }
 
 var operatorNamespace = utils.Call(func() string {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi-operator! -->

# Describe what this PR does #

This patch changes the default update strategy for controller plugin to Recreate from RollingUpdate.

This helps fix the situation where we end up in a scheduling deadlock due to affinity and anti affinity rules.

Fixes: #312, #273

