### PR TITLE
Allow user to specify `imagePullSecrets` for csi-operator deployments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ build-helm-installer: manifests generate kustomize helmify ## Generate helm char
 	mkdir -p build deploy
 	cd build && echo "$$BUILD_INSTALLER_OVERLAY" > kustomization.yaml
 	cd build && $(KUSTOMIZE) edit add resource ../config/default/
-	$(KUSTOMIZE) build build | $(HELMIFY) deploy/charts/ceph-csi-operator
+	$(KUSTOMIZE) build build | $(HELMIFY) -image-pull-secrets deploy/charts/ceph-csi-operator
 	rm -rf build
 
 .PHONY: build-multifile-installer

--- a/Makefile
+++ b/Makefile
@@ -204,6 +204,7 @@ build-helm-installer: manifests generate kustomize helmify ## Generate helm char
 	cd build && echo "$$BUILD_INSTALLER_OVERLAY" > kustomization.yaml
 	cd build && $(KUSTOMIZE) edit add resource ../config/default/
 	$(KUSTOMIZE) build build | $(HELMIFY) -image-pull-secrets deploy/charts/ceph-csi-operator
+	hack/patch-sa-with-imgpullsecrets.sh deploy/charts/ceph-csi-operator
 	rm -rf build
 
 .PHONY: build-multifile-installer

--- a/deploy/charts/ceph-csi-drivers/templates/serviceaccount.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/serviceaccount.yaml
@@ -8,11 +8,19 @@ kind: ServiceAccount
 metadata:
   name: {{ $normalizedDriverName }}-ctrlplugin-sa
   namespace: {{ $root.Release.Namespace }}
+{{- with $root.Values.imagePullSecrets }}
+imagePullSecrets:
+{{ toYaml . | indent 2 }}
+{{- end }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ $normalizedDriverName }}-nodeplugin-sa
   namespace: {{ $root.Release.Namespace }}
+{{- with $root.Values.imagePullSecrets }}
+imagePullSecrets:
+{{ toYaml . | indent 2 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/deploy/charts/ceph-csi-drivers/values.yaml
+++ b/deploy/charts/ceph-csi-drivers/values.yaml
@@ -474,3 +474,6 @@ drivers:
 
       # List of tolerations for the controller plugin
       tolerations: []
+
+# List of pull secret names that will be added to all serviceaccounts
+imagePullSecrets: []

--- a/deploy/charts/ceph-csi-operator/templates/deployment.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/deployment.yaml
@@ -54,6 +54,7 @@ spec:
           }}
         securityContext: {{- toYaml .Values.controllerManager.manager.containerSecurityContext
           | nindent 10 }}
+      imagePullSecrets: {{ .Values.imagePullSecrets | default list | toJson }}
       securityContext: {{- toYaml .Values.controllerManager.podSecurityContext | nindent
         8 }}
       serviceAccountName: {{ include "ceph-csi-operator.fullname" . }}-controller-manager

--- a/deploy/charts/ceph-csi-operator/templates/serviceaccount.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/serviceaccount.yaml
@@ -6,6 +6,10 @@ metadata:
   {{- include "ceph-csi-operator.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.cephfsCtrlpluginSa.serviceAccount.annotations | nindent 4 }}
+{{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+{{ toYaml . | indent 2 }}
+{{- end }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -15,6 +19,10 @@ metadata:
   {{- include "ceph-csi-operator.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.cephfsNodepluginSa.serviceAccount.annotations | nindent 4 }}
+{{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+{{ toYaml . | indent 2 }}
+{{- end }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -24,6 +32,10 @@ metadata:
   {{- include "ceph-csi-operator.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.controllerManager.serviceAccount.annotations | nindent 4 }}
+{{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+{{ toYaml . | indent 2 }}
+{{- end }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -33,6 +45,10 @@ metadata:
   {{- include "ceph-csi-operator.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.nfsCtrlpluginSa.serviceAccount.annotations | nindent 4 }}
+{{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+{{ toYaml . | indent 2 }}
+{{- end }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -42,6 +58,10 @@ metadata:
   {{- include "ceph-csi-operator.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.nfsNodepluginSa.serviceAccount.annotations | nindent 4 }}
+{{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+{{ toYaml . | indent 2 }}
+{{- end }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -51,6 +71,10 @@ metadata:
   {{- include "ceph-csi-operator.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.rbdCtrlpluginSa.serviceAccount.annotations | nindent 4 }}
+{{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+{{ toYaml . | indent 2 }}
+{{- end }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -60,3 +84,7 @@ metadata:
   {{- include "ceph-csi-operator.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.rbdNodepluginSa.serviceAccount.annotations | nindent 4 }}
+{{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+{{ toYaml . | indent 2 }}
+{{- end }}

--- a/deploy/charts/ceph-csi-operator/values.yaml
+++ b/deploy/charts/ceph-csi-operator/values.yaml
@@ -32,6 +32,7 @@ controllerManager:
   replicas: 1
   serviceAccount:
     annotations: {}
+imagePullSecrets: []
 kubernetesClusterDomain: cluster.local
 nfsCtrlpluginSa:
   serviceAccount:

--- a/docs/helm-charts/drivers-chart.md
+++ b/docs/helm-charts/drivers-chart.md
@@ -156,6 +156,7 @@ The following table lists the configurable parameters of the ceph-csi-drivers ch
 | `drivers.rbd.nodePlugin.tolerations` |  | `[]` |
 | `drivers.rbd.nodePlugin.volumes` |  | `[]` |
 | `drivers.rbd.snapshotPolicy` |  | `"none"` |
+| `imagePullSecrets` |  | `[]` |
 | `operatorConfig.create` |  | `true` |
 | `operatorConfig.driverSpecDefaults.attachRequired` |  | `true` |
 | `operatorConfig.driverSpecDefaults.cephFsClientType` |  | `"kernel"` |

--- a/docs/helm-charts/operator-chart.md
+++ b/docs/helm-charts/operator-chart.md
@@ -61,6 +61,7 @@ The following table lists the configurable parameters of the ceph-csi-operator c
 | `controllerManager.podSecurityContext.runAsNonRoot` |  | `true` |
 | `controllerManager.replicas` |  | `1` |
 | `controllerManager.serviceAccount.annotations` |  | `{}` |
+| `imagePullSecrets` |  | `[]` |
 | `kubernetesClusterDomain` |  | `"cluster.local"` |
 | `nfsCtrlpluginSa.serviceAccount.annotations` |  | `{}` |
 | `nfsNodepluginSa.serviceAccount.annotations` |  | `{}` |

--- a/hack/patch-sa-with-imgpullsecrets.sh
+++ b/hack/patch-sa-with-imgpullsecrets.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# DO NOT run this script on its own
+# It will append the required template multiple times
+# It is intended to be ran as a part of generating heml charts using helmify
+
+set -e
+
+CHART_DIR=$1
+SA_FILE="${CHART_DIR}/templates/serviceaccount.yaml"
+
+if [ ! -f "$SA_FILE" ]; then
+  echo "No serviceaccount.yaml template in $CHART_DIR, nothing to do!"
+  exit 1
+fi
+
+TEMPLATE_SNIPPET=$(
+  cat <<'EOF'
+{{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+{{ toYaml . | indent 2 }}
+{{- end }}
+EOF
+)
+
+echo "Patching $SA_FILE for imagePullSecrets"
+
+awk -v snippet="$TEMPLATE_SNIPPET" '
+  # Before printing a separator, print the snippet
+  /^---/ { print snippet }
+
+  # Print the current line
+  { print }
+
+  # At the end of the file, print the snippet for the last section
+  END { print snippet }
+' "$SA_FILE" >"${SA_FILE}.tmp"
+
+mv "${SA_FILE}.tmp" "$SA_FILE"
+
+echo "Patched $SA_FILE successfully"
+exit 0


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi-operator! -->

# Describe what this PR does #

This patch adds option to specify `imagePullSecrets` for operator deployments.

A new `patch-sa-with-imgpullsecrets` script is also added as a post step of `build-helm-installer`
to inject the pull secrets into operator's serviceaccount.

_macOS requires GNU AWK (gawk) installed in order for variable expansion to work properly._


Closes: #305

