### PR TITLE
helm: fix imageSet in driver spec

### DIFF
--- a/deploy/charts/ceph-csi-drivers/templates/driver.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/driver.yaml
@@ -22,8 +22,8 @@ spec:
   {{- end }}
   {{- if $driver.imageSet }}
   {{- if $driver.imageSet.name }}
-    imageSet:
-        name: {{ $driver.imageSet.name }}
+  imageSet:
+    name: {{ $driver.imageSet.name }}
   {{- end }}
   {{- end }}
   clusterName: {{ $driver.clusterName }}


### PR DESCRIPTION
imageSet was not applied properly when the driver was created. this PR fixes the same.

updates: #332 