### PR TITLE
driver: only apply default `cephFSClientType` when unset

### DIFF
--- a/internal/controller/driver_controller.go
+++ b/internal/controller/driver_controller.go
@@ -1849,7 +1849,7 @@ func mergeDriverSpecs(dest, src *csiv1.DriverSpec) {
 	if dest.FuseMountOptions == nil {
 		dest.FuseMountOptions = src.FuseMountOptions
 	}
-	if src.CephFsClientType != "" {
+	if dest.CephFsClientType == "" {
 		dest.CephFsClientType = src.CephFsClientType
 	}
 }


### PR DESCRIPTION
# Describe what this PR does #

Fix a logic error where `driver.cephFSClientType` was always overwritten by the default value from `OperatorConfig`.

The field is now populated from defaults only if it is not already set in the driver spec.

Fixes: #337

