### PR TITLE
api: Update documentation for deployment strategy

### DIFF
--- a/api/v1/driver_types.go
+++ b/api/v1/driver_types.go
@@ -216,7 +216,7 @@ type ControllerPluginSpec struct {
 	PodCommonSpec `json:",inline"`
 
 	// DeploymentStrategy describes how to replace existing pods with new ones
-	// Default value is RollingUpdate with MaxUnavailable and MaxSurege as 25% (kubernetes default)
+	// Default value is Recreate
 	//+kubebuilder:validation:Optional
 	DeploymentStrategy *appsv1.DeploymentStrategy `json:"deploymentStrategy,omitempty"`
 

--- a/config/crd/bases/csi.ceph.io_drivers.yaml
+++ b/config/crd/bases/csi.ceph.io_drivers.yaml
@@ -994,7 +994,7 @@ spec:
                   deploymentStrategy:
                     description: |-
                       DeploymentStrategy describes how to replace existing pods with new ones
-                      Default value is RollingUpdate with MaxUnavailable and MaxSurege as 25% (kubernetes default)
+                      Default value is Recreate
                     properties:
                       rollingUpdate:
                         description: |-

--- a/config/crd/bases/csi.ceph.io_operatorconfigs.yaml
+++ b/config/crd/bases/csi.ceph.io_operatorconfigs.yaml
@@ -1003,7 +1003,7 @@ spec:
                       deploymentStrategy:
                         description: |-
                           DeploymentStrategy describes how to replace existing pods with new ones
-                          Default value is RollingUpdate with MaxUnavailable and MaxSurege as 25% (kubernetes default)
+                          Default value is Recreate
                         properties:
                           rollingUpdate:
                             description: |-

--- a/deploy/all-in-one/install.yaml
+++ b/deploy/all-in-one/install.yaml
@@ -1514,7 +1514,7 @@ spec:
                   deploymentStrategy:
                     description: |-
                       DeploymentStrategy describes how to replace existing pods with new ones
-                      Default value is RollingUpdate with MaxUnavailable and MaxSurege as 25% (kubernetes default)
+                      Default value is Recreate
                     properties:
                       rollingUpdate:
                         description: |-
@@ -15792,7 +15792,7 @@ spec:
                       deploymentStrategy:
                         description: |-
                           DeploymentStrategy describes how to replace existing pods with new ones
-                          Default value is RollingUpdate with MaxUnavailable and MaxSurege as 25% (kubernetes default)
+                          Default value is Recreate
                         properties:
                           rollingUpdate:
                             description: |-

--- a/deploy/charts/ceph-csi-operator/templates/driver-crd.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/driver-crd.yaml
@@ -994,7 +994,7 @@ spec:
                   deploymentStrategy:
                     description: |-
                       DeploymentStrategy describes how to replace existing pods with new ones
-                      Default value is RollingUpdate with MaxUnavailable and MaxSurege as 25% (kubernetes default)
+                      Default value is Recreate
                     properties:
                       rollingUpdate:
                         description: |-

--- a/deploy/charts/ceph-csi-operator/templates/operatorconfig-crd.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/operatorconfig-crd.yaml
@@ -1000,7 +1000,7 @@ spec:
                       deploymentStrategy:
                         description: |-
                           DeploymentStrategy describes how to replace existing pods with new ones
-                          Default value is RollingUpdate with MaxUnavailable and MaxSurege as 25% (kubernetes default)
+                          Default value is Recreate
                         properties:
                           rollingUpdate:
                             description: |-

--- a/deploy/multifile/crd.yaml
+++ b/deploy/multifile/crd.yaml
@@ -1505,7 +1505,7 @@ spec:
                   deploymentStrategy:
                     description: |-
                       DeploymentStrategy describes how to replace existing pods with new ones
-                      Default value is RollingUpdate with MaxUnavailable and MaxSurege as 25% (kubernetes default)
+                      Default value is Recreate
                     properties:
                       rollingUpdate:
                         description: |-
@@ -15783,7 +15783,7 @@ spec:
                       deploymentStrategy:
                         description: |-
                           DeploymentStrategy describes how to replace existing pods with new ones
-                          Default value is RollingUpdate with MaxUnavailable and MaxSurege as 25% (kubernetes default)
+                          Default value is Recreate
                         properties:
                           rollingUpdate:
                             description: |-

--- a/vendor/github.com/ceph/ceph-csi-operator/api/v1/driver_types.go
+++ b/vendor/github.com/ceph/ceph-csi-operator/api/v1/driver_types.go
@@ -216,7 +216,7 @@ type ControllerPluginSpec struct {
 	PodCommonSpec `json:",inline"`
 
 	// DeploymentStrategy describes how to replace existing pods with new ones
-	// Default value is RollingUpdate with MaxUnavailable and MaxSurege as 25% (kubernetes default)
+	// Default value is Recreate
 	//+kubebuilder:validation:Optional
 	DeploymentStrategy *appsv1.DeploymentStrategy `json:"deploymentStrategy,omitempty"`
 


### PR DESCRIPTION


<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi-operator! -->

# Describe what this PR does #

This patch updates the documentation for controller plugin deployment strategy.

It was changed to `Recreate` from `RollingUpdate` with #322

