### PR TITLE
helm: Update controller-plugin deployment strategy to `Recreate`

### DIFF
--- a/deploy/charts/ceph-csi-drivers/values.yaml
+++ b/deploy/charts/ceph-csi-drivers/values.yaml
@@ -141,7 +141,8 @@ operatorConfig:
       resources: {}
 
       # Deployment strategy for the controller plugin
-      deploymentStrategy: {}
+      deploymentStrategy:
+        type: Recreate
 
       # Flag to indicate if the container should be privileged
       privileged: false
@@ -250,7 +251,8 @@ drivers:
       resources: {}
 
       # Deployment strategy for the controller plugin
-      deploymentStrategy: {}
+      deploymentStrategy:
+        type: Recreate
 
       # Flag to indicate if the container should be privileged
       privileged: false
@@ -357,7 +359,8 @@ drivers:
       resources: {}
 
       # Deployment strategy for the controller plugin
-      deploymentStrategy: {}
+      deploymentStrategy:
+        type: Recreate
 
       # Flag to indicate if the container should be privileged
       privileged: false
@@ -467,7 +470,8 @@ drivers:
       resources: {}
 
       # Deployment strategy for the controller plugin
-      deploymentStrategy: {}
+      deploymentStrategy:
+        type: Recreate
 
       # Flag to indicate if the container should be privileged
       privileged: false


### PR DESCRIPTION


<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi-operator! -->

# Describe what this PR does #
This patch updates the default deployment strategy to `Recreate` as per: #322
