### PR TITLE
helm: quote ceph mon addresses in CephConnection

### DIFF
--- a/deploy/charts/ceph-csi-drivers/templates/cephConnection.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/cephConnection.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   monitors:
   {{- range $cephConnection.monitors }}
-  - {{ . }}
+  - {{ . | quote }}
   {{- end }}
   rbdMirrorDaemonCount: {{ $cephConnection.rbdMirrorDaemonCount }}
   readAffinity:


### PR DESCRIPTION


<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi-operator! -->

# Describe what this PR does #

This patch fixes an issue where an invalid YAML was rendered in cases of IPv6 addresses.

The error was due to missing quotes around the addresses.

Fixes: #339

