### PR TITLE
Daemon Sets use Driver Plugin Spec Affinity

### DIFF
--- a/internal/controller/driver_controller.go
+++ b/internal/controller/driver_controller.go
@@ -1118,6 +1118,7 @@ func (r *driverReconcile) reconcileNodePluginDaemonSetForCsiAddons() error {
 					// resolved through k8s service, set dns policy to cluster first
 					DNSPolicy:   corev1.DNSClusterFirstWithHostNet,
 					Tolerations: pluginSpec.Tolerations,
+					Affinity:    pluginSpec.Affinity,
 					Containers: utils.Call(func() []corev1.Container {
 						containers := []corev1.Container{
 							{
@@ -1293,6 +1294,7 @@ func (r *driverReconcile) reconcileNodePluginDaemonSet() error {
 					// resolved through k8s service, set dns policy to cluster first
 					DNSPolicy:   corev1.DNSClusterFirstWithHostNet,
 					Tolerations: pluginSpec.Tolerations,
+					Affinity:    pluginSpec.Affinity,
 					Containers: utils.Call(func() []corev1.Container {
 						containers := []corev1.Container{
 							// Node Plugin Container


### PR DESCRIPTION
the node plugin and other Daemon sets should use the affinity specified in the driver. Example: role=storage-node where non storage-node(s) don't require the node plugin


Weirdly, the rook operator has the code to correctly create the [OperatorConfig](https://github.com/rook/rook/blob/895619262030c5e60196cd29500eced372c17dee/deploy/examples/operator.yaml#L208). it was added in [9d298fe](https://github.com/rook/rook/commit/9d298fe4f00d10337b8bf3032a25c61e03f3acb2)




