### PR TITLE
helm: add missing RBACS for helm charts

### DIFF
--- a/deploy/charts/ceph-csi-drivers/templates/cephfs-ctrlplugin-cr-rbac.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/cephfs-ctrlplugin-cr-rbac.yaml
@@ -156,6 +156,31 @@ rules:
   - update
   - patch
 - apiGroups:
+  - groupsnapshot.storage.openshift.io
+  resources:
+  - volumegroupsnapshotclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - groupsnapshot.storage.openshift.io
+  resources:
+  - volumegroupsnapshotcontents
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - groupsnapshot.storage.openshift.io
+  resources:
+  - volumegroupsnapshotcontents/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
   - ""
   resources:
   - serviceaccounts
@@ -165,6 +190,12 @@ rules:
   - ""
   resources:
   - serviceaccounts/token
+  verbs:
+  - create
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
   verbs:
   - create
 {{- end }}

--- a/deploy/charts/ceph-csi-drivers/templates/cephfs-ctrlplugin-r-rbac.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/cephfs-ctrlplugin-r-rbac.yaml
@@ -48,10 +48,4 @@ rules:
   - daemonsets/finalizers
   verbs:
   - update
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
 {{- end }}

--- a/deploy/charts/ceph-csi-drivers/templates/cephfs-nodeplugin-cr-rbac.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/cephfs-nodeplugin-cr-rbac.yaml
@@ -37,4 +37,21 @@ rules:
   - serviceaccounts/token
   verbs:
   - create
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  - persistentvolumeclaims
+  verbs:
+  - get
 {{- end }}

--- a/deploy/charts/ceph-csi-drivers/templates/cephfs-nodeplugin-r-rbac.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/cephfs-nodeplugin-r-rbac.yaml
@@ -37,10 +37,4 @@ rules:
   - daemonsets/finalizers
   verbs:
   - update
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
 {{- end }}

--- a/deploy/charts/ceph-csi-drivers/templates/rbd-ctrlplugin-cr-rbac.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/rbd-ctrlplugin-cr-rbac.yaml
@@ -168,6 +168,31 @@ rules:
   - update
   - patch
 - apiGroups:
+  - groupsnapshot.storage.openshift.io
+  resources:
+  - volumegroupsnapshotclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - groupsnapshot.storage.openshift.io
+  resources:
+  - volumegroupsnapshotcontents
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - groupsnapshot.storage.openshift.io
+  resources:
+  - volumegroupsnapshotcontents/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
   - replication.storage.openshift.io
   resources:
   - volumegroupreplicationcontents
@@ -183,4 +208,23 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - cbt.storage.k8s.io
+  resources:
+  - snapshotmetadataservices
+  verbs:
+  - get
+  - list
 {{- end }}

--- a/deploy/charts/ceph-csi-drivers/templates/rbd-ctrlplugin-r-rbac.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/rbd-ctrlplugin-r-rbac.yaml
@@ -48,10 +48,4 @@ rules:
   - daemonsets/finalizers
   verbs:
   - update
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
 {{- end }}

--- a/deploy/charts/ceph-csi-drivers/templates/rbd-nodeplugin-cr-rbac.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/rbd-nodeplugin-cr-rbac.yaml
@@ -52,4 +52,26 @@ rules:
   - nodes
   verbs:
   - get
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
 {{- end }}

--- a/deploy/charts/ceph-csi-drivers/templates/rbd-nodeplugin-r-rbac.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/rbd-nodeplugin-r-rbac.yaml
@@ -37,10 +37,4 @@ rules:
   - daemonsets/finalizers
   verbs:
   - update
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
 {{- end }}


### PR DESCRIPTION
There is no direct command to keep the csi rbac in sync for helm, This is identified manually by running helmify against csi-rbac folder.

fixes: #349

