### PR TITLE
Add list and watch RBACs for secrets to nodeplugin clusterroles

### DIFF
--- a/config/csi-rbac/cephfs_nodeplugin_cluster_role.yaml
+++ b/config/csi-rbac/cephfs_nodeplugin_cluster_role.yaml
@@ -9,7 +9,7 @@ rules:
   verbs: ["get"]
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["get"]
+  verbs: ["get", "list", "watch"]
 - apiGroups: [""]
   resources: ["configmaps"]
   verbs: ["get"]

--- a/config/csi-rbac/rbd_nodeplugin_cluster_role.yaml
+++ b/config/csi-rbac/rbd_nodeplugin_cluster_role.yaml
@@ -5,7 +5,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["get", "list"]

--- a/deploy/all-in-one/install.yaml
+++ b/deploy/all-in-one/install.yaml
@@ -29731,6 +29731,8 @@ rules:
   - secrets
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:
@@ -30486,6 +30488,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/deploy/charts/ceph-csi-drivers/templates/cephfs-nodeplugin-cr-rbac.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/cephfs-nodeplugin-cr-rbac.yaml
@@ -19,6 +19,8 @@ rules:
   - secrets
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/deploy/charts/ceph-csi-drivers/templates/rbd-nodeplugin-cr-rbac.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/rbd-nodeplugin-cr-rbac.yaml
@@ -14,6 +14,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/deploy/charts/ceph-csi-operator/templates/cephfs-nodeplugin-cr-rbac.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/cephfs-nodeplugin-cr-rbac.yaml
@@ -17,6 +17,8 @@ rules:
   - secrets
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/deploy/charts/ceph-csi-operator/templates/rbd-nodeplugin-cr-rbac.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/rbd-nodeplugin-cr-rbac.yaml
@@ -12,6 +12,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/deploy/multifile/csi-rbac.yaml
+++ b/deploy/multifile/csi-rbac.yaml
@@ -418,6 +418,8 @@ rules:
   - secrets
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:
@@ -837,6 +839,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION


<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi-operator! -->

# Describe what this PR does #

This patch adds watch and list RBACs to clusterroles for CephFS and RBD nodeplugin.

This is to comply with the enhancement at: https://github.com/ceph/ceph-csi/pull/5497

