### PR TITLE
driver: include csi-addons resource requests in driver

### DIFF
--- a/internal/controller/driver_controller.go
+++ b/internal/controller/driver_controller.go
@@ -1764,6 +1764,9 @@ func mergeDriverSpecs(dest, src *csiv1.DriverSpec) {
 			if dest.Resources.LogRotator == nil {
 				dest.Resources.LogRotator = src.Resources.LogRotator
 			}
+			if dest.Resources.Addons == nil {
+				dest.Resources.Addons = src.Resources.Addons
+			}
 		}
 	}
 	if src.ControllerPlugin != nil {
@@ -1824,6 +1827,9 @@ func mergeDriverSpecs(dest, src *csiv1.DriverSpec) {
 			}
 			if dest.Resources.LogRotator == nil {
 				dest.Resources.LogRotator = src.Resources.LogRotator
+			}
+			if dest.Resources.Addons == nil {
+				dest.Resources.Addons = src.Resources.Addons
 			}
 		}
 	}


### PR DESCRIPTION
# Describe what this PR does #

Currently, the csi-addons resource requests were not respected/merged from operatorconfig with that of the driver, and only the defaults from driver was used. We should check for csi-addons resource definition in operatorconfig and update the driver spec accordingly.