### PR TITLE
Fix nodePlugin affinity not propagating from OperatorConfig to DaemonSet

### DIFF
--- a/internal/controller/driver_controller.go
+++ b/internal/controller/driver_controller.go
@@ -1731,7 +1731,7 @@ func mergeDriverSpecs(dest, src *csiv1.DriverSpec) {
 			if dest.Annotations == nil {
 				dest.Annotations = src.Annotations
 			}
-			if dest.Affinity == nil {
+			if isAffinityEmpty(dest.Affinity) {
 				dest.Affinity = src.Affinity
 			}
 			if dest.Tolerations == nil {
@@ -1786,7 +1786,7 @@ func mergeDriverSpecs(dest, src *csiv1.DriverSpec) {
 			if dest.Annotations == nil {
 				dest.Annotations = src.Annotations
 			}
-			if dest.Affinity == nil {
+			if isAffinityEmpty(dest.Affinity) {
 				dest.Affinity = src.Affinity
 			}
 			if dest.Tolerations == nil {
@@ -1854,4 +1854,15 @@ func mergeDriverSpecs(dest, src *csiv1.DriverSpec) {
 	if dest.CephFsClientType == "" {
 		dest.CephFsClientType = src.CephFsClientType
 	}
+}
+
+// isAffinityEmpty checks if an Affinity is nil or has no meaningful content.
+// This handles the case where an Affinity struct is non-nil but contains only
+// empty nested structs (e.g., &Affinity{NodeAffinity: &NodeAffinity{}}).
+func isAffinityEmpty(affinity *corev1.Affinity) bool {
+	if affinity == nil {
+		return true
+	}
+	return reflect.DeepEqual(affinity, &corev1.Affinity{}) ||
+		reflect.DeepEqual(affinity, &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{}})
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi-operator! -->

# Describe what this PR does #

When using the ceph-csi-operator with Rook, node affinity configured in the OperatorConfig's `driverSpecDefaults.nodePlugin.affinity` is ignored.

The CSI nodeplugin DaemonSet runs on all nodes regardless of the configured affinity rules.

**Root cause:** Rook's operator creates Driver CRs with a non-nil but empty `Affinity` struct:
```go
Affinity: &corev1.Affinity{
    NodeAffinity: getNodeAffinity(pluginNodeAffinityEnv, &corev1.NodeAffinity{}),
}
```

The mergeDriverSpecs() function only checks if `dest.Affinity == nil` before merging defaults from OperatorConfig. Since the Affinity pointer is an empty struct (never nil!), the merge never happens.

## Example Scenario

In my cluster, there are some nodes that won't ever run pods that need Ceph PVCs. If we don't run a DaemonSet on these nodes, we can free up some requests, which is especially beneficial for smaller nodes.

## Is there anything that requires special attention ##

Do you have any questions?

Is the change backward compatible?

Are there concerns around backward compatibility?

Provide any external context for the change, if any.

For example:

* Kubernetes links that explain why the change is required
* Ceph-CSI spec related changes/catch-up that necessitates this patch
* golang related practices that necessitates this change

## Related issues ##

Mention any github issues relevant to this PR. Adding below line
will help to auto close the issue once the PR is merged.

Fixes: #issue_number

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#development-workflow)
* [x] [Pending release
  notes](https://github.com/ceph/ceph-csi-operator/blob/main/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [x] Documentation has been updated, if necessary.
* [x] Unit tests have been added, if necessary.
* [x] Integration tests have been added, if necessary.
