### PR TITLE
Explicitly set namespace for Ceph CSI operator/driver resources

### DIFF
--- a/deploy/charts/ceph-csi-drivers/templates/cephfs-ctrlplugin-r-rbac.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/cephfs-ctrlplugin-r-rbac.yaml
@@ -6,6 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ $normalizedDriverName }}-ctrlplugin-r
+  namespace: {{ $root.Release.Namespace }}
 rules:
 - apiGroups:
   - coordination.k8s.io

--- a/deploy/charts/ceph-csi-drivers/templates/cephfs-ctrlplugin-rb-rbac.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/cephfs-ctrlplugin-rb-rbac.yaml
@@ -6,10 +6,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ $normalizedDriverName }}-ctrlplugin-rb
+  namespace: {{ $root.Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: {{ $normalizedDriverName }}-ctrlplugin-r
+  namespace: {{ $root.Release.Namespace }}
 subjects:
 - kind: ServiceAccount
   name: {{ $normalizedDriverName }}-ctrlplugin-sa

--- a/deploy/charts/ceph-csi-drivers/templates/cephfs-nodeplugin-r-rbac.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/cephfs-nodeplugin-r-rbac.yaml
@@ -6,6 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ $normalizedDriverName }}-nodeplugin-r
+  namespace: {{ $root.Release.Namespace }}
 rules:
 - apiGroups:
   - csiaddons.openshift.io

--- a/deploy/charts/ceph-csi-drivers/templates/cephfs-nodeplugin-rb-rbac.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/cephfs-nodeplugin-rb-rbac.yaml
@@ -6,10 +6,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ $normalizedDriverName }}-nodeplugin-rb
+  namespace: {{ $root.Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: {{ $normalizedDriverName }}-nodeplugin-r
+  namespace: {{ $root.Release.Namespace }}
 subjects:
 - kind: ServiceAccount
   name: {{ $normalizedDriverName }}-nodeplugin-sa

--- a/deploy/charts/ceph-csi-drivers/templates/rbd-ctrlplugin-r-rbac.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/rbd-ctrlplugin-r-rbac.yaml
@@ -6,6 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ $normalizedDriverName }}-ctrlplugin-r
+  namespace: {{ $root.Release.Namespace }}
 rules:
 - apiGroups:
   - coordination.k8s.io

--- a/deploy/charts/ceph-csi-drivers/templates/rbd-ctrlplugin-rb-rbac.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/rbd-ctrlplugin-rb-rbac.yaml
@@ -6,10 +6,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ $normalizedDriverName }}-ctrlplugin-rb
+  namespace: {{ $root.Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: {{ $normalizedDriverName }}-ctrlplugin-r
+  namespace: {{ $root.Release.Namespace }}
 subjects:
 - kind: ServiceAccount
   name: {{ $normalizedDriverName }}-ctrlplugin-sa

--- a/deploy/charts/ceph-csi-drivers/templates/rbd-nodeplugin-r-rbac.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/rbd-nodeplugin-r-rbac.yaml
@@ -6,6 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ $normalizedDriverName }}-nodeplugin-r
+  namespace: {{ $root.Release.Namespace }}
 rules:
 - apiGroups:
   - csiaddons.openshift.io

--- a/deploy/charts/ceph-csi-drivers/templates/rbd-nodeplugin-rb-rbac.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/rbd-nodeplugin-rb-rbac.yaml
@@ -10,6 +10,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: {{ $normalizedDriverName }}-nodeplugin-r
+  namespace: {{ $root.Release.Namespace }}
 subjects:
 - kind: ServiceAccount
   name: {{ $normalizedDriverName }}-nodeplugin-sa

--- a/deploy/charts/ceph-csi-operator/templates/cephfs-ctrlplugin-r-rbac.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/cephfs-ctrlplugin-r-rbac.yaml
@@ -2,6 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "ceph-csi-operator.fullname" . }}-cephfs-ctrlplugin-r
+  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "ceph-csi-operator.labels" . | nindent 4 }}
 rules:

--- a/deploy/charts/ceph-csi-operator/templates/cephfs-ctrlplugin-rb-rbac.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/cephfs-ctrlplugin-rb-rbac.yaml
@@ -8,6 +8,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: '{{ include "ceph-csi-operator.fullname" . }}-cephfs-ctrlplugin-r'
+  namespace: {{ .Release.Namespace }}
 subjects:
 - kind: ServiceAccount
   name: '{{ include "ceph-csi-operator.fullname" . }}-cephfs-ctrlplugin-sa'

--- a/deploy/charts/ceph-csi-operator/templates/cephfs-nodeplugin-r-rbac.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/cephfs-nodeplugin-r-rbac.yaml
@@ -2,6 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "ceph-csi-operator.fullname" . }}-cephfs-nodeplugin-r
+  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "ceph-csi-operator.labels" . | nindent 4 }}
 rules:

--- a/deploy/charts/ceph-csi-operator/templates/cephfs-nodeplugin-rb-rbac.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/cephfs-nodeplugin-rb-rbac.yaml
@@ -8,6 +8,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: '{{ include "ceph-csi-operator.fullname" . }}-cephfs-nodeplugin-r'
+  namespace: {{ .Release.Namespace }}
 subjects:
 - kind: ServiceAccount
   name: '{{ include "ceph-csi-operator.fullname" . }}-cephfs-nodeplugin-sa'

--- a/deploy/charts/ceph-csi-operator/templates/deployment.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "ceph-csi-operator.fullname" . }}-controller-manager
+  namespace: {{ .Release.Namespace }}
   labels:
     control-plane: controller-manager
   {{- include "ceph-csi-operator.labels" . | nindent 4 }}

--- a/deploy/charts/ceph-csi-operator/templates/leader-election-rbac.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/leader-election-rbac.yaml
@@ -2,6 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "ceph-csi-operator.fullname" . }}-leader-election-role
+  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "ceph-csi-operator.labels" . | nindent 4 }}
 rules:
@@ -47,6 +48,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: '{{ include "ceph-csi-operator.fullname" . }}-leader-election-role'
+  namespace: {{ .Release.Namespace }}
 subjects:
 - kind: ServiceAccount
   name: '{{ include "ceph-csi-operator.fullname" . }}-controller-manager'

--- a/deploy/charts/ceph-csi-operator/templates/rbd-ctrlplugin-r-rbac.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/rbd-ctrlplugin-r-rbac.yaml
@@ -2,6 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "ceph-csi-operator.fullname" . }}-rbd-ctrlplugin-r
+  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "ceph-csi-operator.labels" . | nindent 4 }}
 rules:

--- a/deploy/charts/ceph-csi-operator/templates/rbd-ctrlplugin-rb-rbac.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/rbd-ctrlplugin-rb-rbac.yaml
@@ -8,6 +8,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: '{{ include "ceph-csi-operator.fullname" . }}-rbd-ctrlplugin-r'
+  namespace: {{ .Release.Namespace }}
 subjects:
 - kind: ServiceAccount
   name: '{{ include "ceph-csi-operator.fullname" . }}-rbd-ctrlplugin-sa'

--- a/deploy/charts/ceph-csi-operator/templates/rbd-nodeplugin-r-rbac.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/rbd-nodeplugin-r-rbac.yaml
@@ -2,6 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "ceph-csi-operator.fullname" . }}-rbd-nodeplugin-r
+  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "ceph-csi-operator.labels" . | nindent 4 }}
 rules:

--- a/deploy/charts/ceph-csi-operator/templates/rbd-nodeplugin-rb-rbac.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/rbd-nodeplugin-rb-rbac.yaml
@@ -8,6 +8,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: '{{ include "ceph-csi-operator.fullname" . }}-rbd-nodeplugin-r'
+  namespace: {{ .Release.Namespace }}
 subjects:
 - kind: ServiceAccount
   name: '{{ include "ceph-csi-operator.fullname" . }}-rbd-nodeplugin-sa'

--- a/deploy/charts/ceph-csi-operator/templates/serviceaccount.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "ceph-csi-operator.fullname" . }}-cephfs-ctrlplugin-sa
+  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "ceph-csi-operator.labels" . | nindent 4 }}
   annotations:
@@ -15,6 +16,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "ceph-csi-operator.fullname" . }}-cephfs-nodeplugin-sa
+  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "ceph-csi-operator.labels" . | nindent 4 }}
   annotations:
@@ -28,6 +30,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "ceph-csi-operator.fullname" . }}-controller-manager
+  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "ceph-csi-operator.labels" . | nindent 4 }}
   annotations:
@@ -41,6 +44,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "ceph-csi-operator.fullname" . }}-nfs-ctrlplugin-sa
+  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "ceph-csi-operator.labels" . | nindent 4 }}
   annotations:
@@ -54,6 +58,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "ceph-csi-operator.fullname" . }}-nfs-nodeplugin-sa
+  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "ceph-csi-operator.labels" . | nindent 4 }}
   annotations:
@@ -67,6 +72,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "ceph-csi-operator.fullname" . }}-rbd-ctrlplugin-sa
+  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "ceph-csi-operator.labels" . | nindent 4 }}
   annotations:
@@ -80,6 +86,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "ceph-csi-operator.fullname" . }}-rbd-nodeplugin-sa
+  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "ceph-csi-operator.labels" . | nindent 4 }}
   annotations:


### PR DESCRIPTION
Add explicitly namespace name for CephCSI operator resources to have an ability specify it during helm install.

Fixes: #384

