### PR TITLE
rbac: add volumeattributesclasses clusterroles for rbd ,cephfs and nfs

### DIFF
--- a/config/csi-rbac/cephfs_ctrlplugin_cluster_role.yaml
+++ b/config/csi-rbac/cephfs_ctrlplugin_cluster_role.yaml
@@ -75,3 +75,6 @@ rules:
   - apiGroups: ["authentication.k8s.io"]
     resources: ["tokenreviews"]
     verbs: ["create"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattributesclasses"]
+    verbs: ["get", "list", "watch"]

--- a/config/csi-rbac/nfs_ctrlplugin_cluster_role.yaml
+++ b/config/csi-rbac/nfs_ctrlplugin_cluster_role.yaml
@@ -49,3 +49,6 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments/status"]
     verbs: ["patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattributesclasses"]
+    verbs: ["get", "list", "watch"]

--- a/config/csi-rbac/rbd_ctrlplugin_cluster_role.yaml
+++ b/config/csi-rbac/rbd_ctrlplugin_cluster_role.yaml
@@ -87,3 +87,6 @@ rules:
   - apiGroups: ["cbt.storage.k8s.io"]
     resources: ["snapshotmetadataservices"]
     verbs: ["get", "list"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattributesclasses"]
+    verbs: ["get", "list", "watch"]

--- a/deploy/all-in-one/install.yaml
+++ b/deploy/all-in-one/install.yaml
@@ -29865,6 +29865,14 @@ rules:
   - tokenreviews
   verbs:
   - create
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattributesclasses
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -30345,6 +30353,14 @@ rules:
   - volumeattachments/status
   verbs:
   - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattributesclasses
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -30633,6 +30649,14 @@ rules:
   verbs:
   - get
   - list
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattributesclasses
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/deploy/charts/ceph-csi-operator/templates/cephfs-ctrlplugin-cr-rbac.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/cephfs-ctrlplugin-cr-rbac.yaml
@@ -196,3 +196,11 @@ rules:
   - tokenreviews
   verbs:
   - create
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattributesclasses
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy/charts/ceph-csi-operator/templates/nfs-ctrlplugin-cr-rbac.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/nfs-ctrlplugin-cr-rbac.yaml
@@ -132,3 +132,11 @@ rules:
   - volumeattachments/status
   verbs:
   - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattributesclasses
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy/charts/ceph-csi-operator/templates/rbd-ctrlplugin-cr-rbac.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/rbd-ctrlplugin-cr-rbac.yaml
@@ -225,3 +225,11 @@ rules:
   verbs:
   - get
   - list
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattributesclasses
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy/multifile/csi-rbac.yaml
+++ b/deploy/multifile/csi-rbac.yaml
@@ -400,6 +400,14 @@ rules:
   - tokenreviews
   verbs:
   - create
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattributesclasses
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -594,6 +602,14 @@ rules:
   - volumeattachments/status
   verbs:
   - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattributesclasses
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -832,6 +848,14 @@ rules:
   verbs:
   - get
   - list
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattributesclasses
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION


<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi-operator! -->

# Describe what this PR does #

```
csi-resizer v0.2.0 moves the VolumeAttributesClass feature gate to GA.
Add the required ClusterRole to prevent error logs in the csi-resizer sidecar. 
Resolves #396.
```

Fixes: #396 

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#development-workflow)
* [x] [Pending release notes](https://github.com/ceph/ceph-csi-operator/blob/main/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [x] Documentation has been updated, if necessary.
* [x] Unit tests have been added, if necessary.
* [x] Integration tests have been added, if necessary.
