### PR TITLE
Fix Common preparation Step in Migration Guide

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -54,9 +54,16 @@ kubectl delete -f backup/ceph-csi/workloads.yaml
 kubectl delete -f backup/ceph-csi/csidriver.yaml
 kubectl delete -f backup/ceph-csi/rbac.yaml
 kubectl delete -f backup/ceph-csi/configmaps.yaml
-kubectl delete clusterrolebinding.rbac.authorization.k8s.io/rbd-csi-provisioner-role
 kubectl delete clusterrolebinding.rbac.authorization.k8s.io/rbd-csi-nodeplugin
 kubectl delete clusterrole.rbac.authorization.k8s.io/rbd-csi-nodeplugin
+kubectl delete clusterrolebinding.rbac.authorization.k8s.io/rbd-csi-provisioner-role
+kubectl delete clusterrole.rbac.authorization.k8s.io/rbd-external-provisioner-runner
+kubectl delete clusterrolebinding.rbac.authorization.k8s.io/nfs-csi-provisioner-role
+kubectl delete clusterrole.rbac.authorization.k8s.io/nfs-external-provisioner-runner
+kubectl delete clusterrolebinding.rbac.authorization.k8s.io/cephfs-csi-nodeplugin
+kubectl delete clusterrole.rbac.authorization.k8s.io/cephfs-csi-nodeplugin
+kubectl delete clusterrole.rbac.authorization.k8s.io/cephfs-external-provisioner-runner
+kubectl delete clusterrolebinding.rbac.authorization.k8s.io/cephfs-csi-provisioner-role
 ```
 
 Make sure the above yamls contains only the ceph-CSI resources before issuing delete.


### PR DESCRIPTION


<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi-operator! -->

# Describe what this PR does #


This PR is simply fixing some line on the migration.md file 
On the migration guide, the common preparation commands were too wide. Clusterrole and Clusterrolebinding can not be retrieved by the ceph-csi namespace because they are cluster-wide resources. This commit narrows down the scope of the command to the ceph-csi namespace. Also i added a delete command for the actual clusterrrole and clusterrolebinding to be deleted in the next step.


## Is there anything that requires special attention ##

If not changed and someone follow that guide he will delete every ClusterRole and ClusterRoleBinding on their cluster

## Related issues ##

Mention any github issues relevant to this PR. Adding below line
will help to auto close the issue once the PR is merged.

Fixes: #issue_number

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

**Checklist:**

* [X] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#commit-messages).
* [X] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi-operator/blob/main/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [X] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.
