### PR TITLE
fix: add if checks to fix driver charts

### DIFF
--- a/deploy/charts/ceph-csi-drivers/templates/driver.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/driver.yaml
@@ -17,7 +17,9 @@ spec:
       maxFiles: {{ $driver.log.rotation.maxFiles }}
       maxLogSize: {{ $driver.log.rotation.maxLogSize }}
       periodicity: {{ $driver.log.rotation.periodicity }}
+      {{- if $driver.log.rotation.logHostPath }}
       logHostPath: {{ $driver.log.rotation.logHostPath }}
+      {{- end }}
     {{- end }}
   {{- end }}
   {{- if $driver.imageSet }}
@@ -26,7 +28,9 @@ spec:
     name: {{ $driver.imageSet.name }}
   {{- end }}
   {{- end }}
+  {{- if $driver.clusterName }}
   clusterName: {{ $driver.clusterName }}
+  {{- end }}
   enableMetadata: {{ $driver.enableMetadata }}
   grpcTimeout: {{ $driver.grpcTimeout }}
   snapshotPolicy: {{ $driver.snapshotPolicy }}
@@ -58,7 +62,9 @@ spec:
   nodePlugin:
     serviceAccountName: {{ $normalizedDriverName }}-nodeplugin-sa
     {{- if $driver.nodePlugin }}
-    updateStrategy: {{ $driver.nodePlugin.updateStrategy | toYaml | nindent 8 }}
+    {{- if $driver.nodePlugin.updateStrategy }}
+    updateStrategy: {{ $driver.nodePlugin.updateStrategy | toYaml | nindent 6 }}
+    {{- end }}
     {{- if $driver.nodePlugin.resources }}
     resources:
       registrar: {{ $driver.nodePlugin.resources.registrar | toYaml | nindent 4 }}
@@ -67,14 +73,28 @@ spec:
       logRotator: {{ $driver.nodePlugin.resources.logRotator | toYaml | nindent 4 }}
       plugin: {{ $driver.nodePlugin.resources.plugin | toYaml | nindent 4 }}
     {{- end }}
+    {{- if $driver.nodePlugin.kubeletDirPath }}
     kubeletDirPath: {{ $driver.nodePlugin.kubeletDirPath }}
+    {{- end }}
+    {{- if ne $driver.nodePlugin.enableSeLinuxHostMount nil }}
     enableSeLinuxHostMount: {{ $driver.nodePlugin.enableSeLinuxHostMount }}
+    {{- end }}
+    {{- if $driver.nodePlugin.priorityClassName }}
     priorityClassName: {{ $driver.nodePlugin.priorityClassName }}
-    labels: {{ $driver.nodePlugin.labels | toYaml | nindent 8 }}
-    annotations: {{ $driver.nodePlugin.annotations | toYaml | nindent 8 }}
-    affinity: {{ $driver.nodePlugin.affinity | toYaml | nindent 8 }}
+    {{- end }}
+    {{- if $driver.nodePlugin.labels }}
+    labels: {{ $driver.nodePlugin.labels | toYaml | nindent 6 }}
+    {{- end }}
+    {{- if $driver.nodePlugin.annotations }}
+    annotations: {{ $driver.nodePlugin.annotations | toYaml | nindent 6 }}
+    {{- end }}
+    {{- if $driver.nodePlugin.affinity }}
+    affinity: {{ $driver.nodePlugin.affinity | toYaml | nindent 6 }}
+    {{- end }}
     tolerations: {{ $driver.nodePlugin.tolerations | toYaml | nindent 8 }}
+    {{- if $driver.nodePlugin.imagePullPolicy }}
     imagePullPolicy: {{ $driver.nodePlugin.imagePullPolicy }}
+    {{- end }}
     {{- if $driver.nodePlugin.topology }}
       topology:
         domainLabels:
@@ -92,7 +112,9 @@ spec:
     serviceAccountName: {{ $normalizedDriverName }}-ctrlplugin-sa
     {{- if $driver.controllerPlugin }}
     hostNetwork: {{ $driver.controllerPlugin.hostNetwork | default false }}
-    deploymentStrategy: {{ $driver.controllerPlugin.deploymentStrategy | toYaml | nindent 8 }}
+    {{- if $driver.controllerPlugin.deploymentStrategy }}
+    deploymentStrategy: {{ $driver.controllerPlugin.deploymentStrategy | toYaml | nindent 6 }}
+    {{- end }}
     replicas: {{ $driver.controllerPlugin.replicas | default 2 }}
     {{- if $driver.controllerPlugin.resources }}
     resources:
@@ -107,8 +129,12 @@ spec:
       plugin: {{ $driver.controllerPlugin.resources.plugin | toYaml | nindent 8 }}
     {{- end }}
     privileged: {{ $driver.controllerPlugin.privileged | default false }}
+    {{- if $driver.controllerPlugin.priorityClassName }}
     priorityClassName: {{ $driver.controllerPlugin.priorityClassName }}
-    affinity: {{ $driver.controllerPlugin.affinity | toYaml | nindent 8 }}
+    {{- end }}
+    {{- if $driver.controllerPlugin.affinity }}
+    affinity: {{ $driver.controllerPlugin.affinity | toYaml | nindent 6 }}
+    {{- end }}
     tolerations:
     {{- toYaml $driver.controllerPlugin.tolerations | nindent 8 }}
     volumes:
@@ -117,7 +143,9 @@ spec:
       {{- else }}
       []
       {{- end }}
+    {{- if $driver.controllerPlugin.imagePullPolicy }}
     imagePullPolicy: {{ $driver.controllerPlugin.imagePullPolicy }}
+    {{- end }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/deploy/charts/ceph-csi-drivers/templates/operatorConfig.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/operatorConfig.yaml
@@ -21,7 +21,9 @@ spec:
         maxFiles: {{ $config.driverSpecDefaults.log.rotation.maxFiles }}
         maxLogSize: {{ $config.driverSpecDefaults.log.rotation.maxLogSize }}
         periodicity: {{ $config.driverSpecDefaults.log.rotation.periodicity }}
+        {{- if $config.driverSpecDefaults.log.rotation.logHostPath }}
         logHostPath: {{ $config.driverSpecDefaults.log.rotation.logHostPath }}
+        {{- end }}
       {{- end }}
     {{- end }}
     {{- if $config.driverSpecDefaults.imageSet }}
@@ -30,7 +32,9 @@ spec:
         name: {{ $config.driverSpecDefaults.imageSet.name }}
     {{- end }}
     {{- end }}
+    {{- if $config.driverSpecDefaults.clusterName }}
     clusterName: {{ $config.driverSpecDefaults.clusterName }}
+    {{- end }}
     enableMetadata: {{ $config.driverSpecDefaults.enableMetadata }}
     grpcTimeout: {{ $config.driverSpecDefaults.grpcTimeout }}
     snapshotPolicy: {{ $config.driverSpecDefaults.snapshotPolicy }}
@@ -72,14 +76,28 @@ spec:
         logRotator: {{ $config.driverSpecDefaults.nodePlugin.resources.logRotator | toYaml | nindent 4 }}
         plugin: {{ $config.driverSpecDefaults.nodePlugin.resources.plugin | toYaml | nindent 4 }}
       {{- end }}
+      {{- if $config.driverSpecDefaults.nodePlugin.kubeletDirPath }}
       kubeletDirPath: {{ $config.driverSpecDefaults.nodePlugin.kubeletDirPath }}
+      {{- end }}
+      {{- if ne $config.driverSpecDefaults.nodePlugin.enableSeLinuxHostMount nil }}
       enableSeLinuxHostMount: {{ $config.driverSpecDefaults.nodePlugin.enableSeLinuxHostMount }}
+      {{- end }}
+      {{- if $config.driverSpecDefaults.nodePlugin.priorityClassName }}
       priorityClassName: {{ $config.driverSpecDefaults.nodePlugin.priorityClassName }}
+      {{- end }}
+      {{- if $config.driverSpecDefaults.nodePlugin.labels }}
       labels: {{ $config.driverSpecDefaults.nodePlugin.labels | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if $config.driverSpecDefaults.nodePlugin.annotations }}
       annotations: {{ $config.driverSpecDefaults.nodePlugin.annotations | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if $config.driverSpecDefaults.nodePlugin.affinity }}
       affinity: {{ $config.driverSpecDefaults.nodePlugin.affinity | toYaml | nindent 8 }}
+      {{- end }}
       tolerations: {{ $config.driverSpecDefaults.nodePlugin.tolerations | toYaml | nindent 8 }}
+      {{- if $config.driverSpecDefaults.nodePlugin.imagePullPolicy }}
       imagePullPolicy: {{ $config.driverSpecDefaults.nodePlugin.imagePullPolicy }}
+      {{- end }}
       {{- if $config.driverSpecDefaults.nodePlugin.topology }}
         topology:
           domainLabels:
@@ -96,7 +114,9 @@ spec:
     controllerPlugin:
       {{- if $config.driverSpecDefaults.controllerPlugin }}
       hostNetwork: {{ $config.driverSpecDefaults.controllerPlugin.hostNetwork | default false }}
+      {{- if $config.driverSpecDefaults.controllerPlugin.deploymentStrategy }}
       deploymentStrategy: {{ $config.driverSpecDefaults.controllerPlugin.deploymentStrategy | toYaml | nindent 8 }}
+      {{- end }}
       replicas: {{ $config.driverSpecDefaults.controllerPlugin.replicas | default 2 }}
       {{- if $config.driverSpecDefaults.controllerPlugin.resources }}
       resources:
@@ -111,8 +131,12 @@ spec:
         plugin: {{ $config.driverSpecDefaults.controllerPlugin.resources.plugin | toYaml | nindent 8 }}
       {{- end }}
       privileged: {{ $config.driverSpecDefaults.controllerPlugin.privileged | default false }}
+      {{- if $config.driverSpecDefaults.controllerPlugin.priorityClassName }}
       priorityClassName: {{ $config.driverSpecDefaults.controllerPlugin.priorityClassName }}
+      {{- end }}
+      {{- if $config.driverSpecDefaults.controllerPlugin.affinity }}
       affinity: {{ $config.driverSpecDefaults.controllerPlugin.affinity | toYaml | nindent 8 }}
+      {{- end }}
       tolerations:
       {{- toYaml $config.driverSpecDefaults.controllerPlugin.tolerations | nindent 8 }}
       volumes:
@@ -121,6 +145,8 @@ spec:
         {{- else }}
         []
         {{- end }}
+      {{- if $config.driverSpecDefaults.controllerPlugin.imagePullPolicy }}
       imagePullPolicy: {{ $config.driverSpecDefaults.controllerPlugin.imagePullPolicy }}
+      {{- end }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
We dont have this issue when we run the helm tests in the CI but am able to reproduce this locally, This PR adds extra checks to ensure that values are set only when specified.

closes: #407


## without changes

```
[🎩︎]mrajanna: ceph-csi-operator $]helm install ceph-csi-drivers --create-namespace --namespace ceph-csi-driver deploy/charts/ceph-csi-drivers/
Error: INSTALLATION FAILED: Driver.csi.ceph.io "nfs.csi.ceph.com" is invalid: [spec.controllerPlugin.priorityClassName: Invalid value: "null": spec.controllerPlugin.priorityClassName in body must be of type string: "null", spec.controllerPlugin.affinity: Invalid value: "null": spec.controllerPlugin.affinity in body must be of type object: "null", spec.controllerPlugin.imagePullPolicy: Invalid value: "null": spec.controllerPlugin.imagePullPolicy in body must be of type string: "null", spec.nodePlugin.kubeletDirPath: Invalid value: "null": spec.nodePlugin.kubeletDirPath in body must be of type string: "null", spec.nodePlugin.priorityClassName: Invalid value: "null": spec.nodePlugin.priorityClassName in body must be of type string: "null", spec.nodePlugin.enableSeLinuxHostMount: Invalid value: "null": spec.nodePlugin.enableSeLinuxHostMount in body must be of type boolean: "null", spec.nodePlugin.updateStrategy: Invalid value: "null": spec.nodePlugin.updateStrategy in body must be of type object: "null", spec.clusterName: Invalid value: "null": spec.clusterName in body must be of type string: "null", spec.log.rotation.logHostPath: Invalid value: "null": spec.log.rotation.logHostPath in body must be of type string: "null", <nil>: Invalid value: null: some validation rules were not checked because the object was invalid; correct the existing errors to complete validation]
Driver.csi.ceph.io "cephfs.csi.ceph.com" is invalid: [spec.nodePlugin.kubeletDirPath: Invalid value: "null": spec.nodePlugin.kubeletDirPath in body must be of type string: "null", spec.nodePlugin.priorityClassName: Invalid value: "null": spec.nodePlugin.priorityClassName in body must be of type string: "null", spec.nodePlugin.enableSeLinuxHostMount: Invalid value: "null": spec.nodePlugin.enableSeLinuxHostMount in body must be of type boolean: "null", spec.nodePlugin.updateStrategy: Invalid value: "null": spec.nodePlugin.updateStrategy in body must be of type object: "null", spec.clusterName: Invalid value: "null": spec.clusterName in body must be of type string: "null", spec.log.rotation.logHostPath: Invalid value: "null": spec.log.rotation.logHostPath in body must be of type string: "null", spec.controllerPlugin.affinity: Invalid value: "null": spec.controllerPlugin.affinity in body must be of type object: "null", spec.controllerPlugin.imagePullPolicy: Invalid value: "null": spec.controllerPlugin.imagePullPolicy in body must be of type string: "null", spec.controllerPlugin.priorityClassName: Invalid value: "null": spec.controllerPlugin.priorityClassName in body must be of type string: "null", <nil>: Invalid value: null: some validation rules were not checked because the object was invalid; correct the existing errors to complete validation]
Driver.csi.ceph.io "rbd.csi.ceph.com" is invalid: [spec.controllerPlugin.priorityClassName: Invalid value: "null": spec.controllerPlugin.priorityClassName in body must be of type string: "null", spec.controllerPlugin.affinity: Invalid value: "null": spec.controllerPlugin.affinity in body must be of type object: "null", spec.controllerPlugin.imagePullPolicy: Invalid value: "null": spec.controllerPlugin.imagePullPolicy in body must be of type string: "null", spec.nodePlugin.priorityClassName: Invalid value: "null": spec.nodePlugin.priorityClassName in body must be of type string: "null", spec.nodePlugin.enableSeLinuxHostMount: Invalid value: "null": spec.nodePlugin.enableSeLinuxHostMount in body must be of type boolean: "null", spec.nodePlugin.updateStrategy: Invalid value: "null": spec.nodePlugin.updateStrategy in body must be of type object: "null", spec.nodePlugin.kubeletDirPath: Invalid value: "null": spec.nodePlugin.kubeletDirPath in body must be of type string: "null", spec.clusterName: Invalid value: "null": spec.clusterName in body must be of type string: "null", spec.log.rotation.logHostPath: Invalid value: "null": spec.log.rotation.logHostPath in body must be of type string: "null", <nil>: Invalid value: null: some validation rules were not checked because the object was invalid; correct the existing errors to complete validation]
OperatorConfig.csi.ceph.io "ceph-csi-operator-config" is invalid: [spec.driverSpecDefaults.controllerPlugin.priorityClassName: Invalid value: "null": spec.driverSpecDefaults.controllerPlugin.priorityClassName in body must be of type string: "null", spec.driverSpecDefaults.log.rotation.logHostPath: Invalid value: "null": spec.driverSpecDefaults.log.rotation.logHostPath in body must be of type string: "null", spec.driverSpecDefaults.clusterName: Invalid value: "null": spec.driverSpecDefaults.clusterName in body must be of type string: "null", spec.driverSpecDefaults.nodePlugin.priorityClassName: Invalid value: "null": spec.driverSpecDefaults.nodePlugin.priorityClassName in body must be of type string: "null", spec.driverSpecDefaults.nodePlugin.enableSeLinuxHostMount: Invalid value: "null": spec.driverSpecDefaults.nodePlugin.enableSeLinuxHostMount in body must be of type boolean: "null", <nil>: Invalid value: null: some validation rules were not checked because the object was invalid; correct the existing errors to complete validation]
[🎩︎]mrajanna: ceph-csi-operator $]
```

## With this change

```
[🎩︎]mrajanna: ceph-csi-operator $]`unsta': helm uninstall ceph-csi-drivers -n ceph-csi-driver
release "ceph-csi-drivers" uninstalled
[🎩︎]mrajanna: ceph-csi-operator $]helm install ceph-csi-drivers --create-namespace --namespace ceph-csi-driver deploy/charts/ceph-csi-drivers/
NAME: ceph-csi-drivers
LAST DEPLOYED: Fri Feb 20 11:03:53 2026
NAMESPACE: ceph-csi-driver
STATUS: deployed
REVISION: 1
DESCRIPTION: Install complete
TEST SUITE: None
```