### PR TITLE
deploy: update CSI sidecars to latest versions available

### DIFF
--- a/internal/controller/defaults.go
+++ b/internal/controller/defaults.go
@@ -28,11 +28,11 @@ import (
 )
 
 var imageDefaults = map[string]string{
-	"provisioner":       "registry.k8s.io/sig-storage/csi-provisioner:v6.0.0",
-	"attacher":          "registry.k8s.io/sig-storage/csi-attacher:v4.10.0",
-	"resizer":           "registry.k8s.io/sig-storage/csi-resizer:v2.0.0",
-	"snapshotter":       "registry.k8s.io/sig-storage/csi-snapshotter:v8.4.0",
-	"registrar":         "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.15.0",
+	"provisioner":       "registry.k8s.io/sig-storage/csi-provisioner:v6.1.1",
+	"attacher":          "registry.k8s.io/sig-storage/csi-attacher:v4.11.0",
+	"resizer":           "registry.k8s.io/sig-storage/csi-resizer:v2.1.0",
+	"snapshotter":       "registry.k8s.io/sig-storage/csi-snapshotter:v8.5.0",
+	"registrar":         "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0",
 	"snapshot-metadata": "registry.k8s.io/sig-storage/csi-snapshot-metadata:v0.2.0",
 	"plugin":            "quay.io/cephcsi/cephcsi:v3.16.1",
 	"addons":            "quay.io/csiaddons/k8s-sidecar:v0.14.0",


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi-operator! -->

# Describe what this PR does #

Updated the following csi sidecars to their latest available versions:
- csi-attacher: v4.11.0
- csi-snapshotter: v8.5.0
- csi-resizer: v2.1.0
- csi-provisioner: v6.1.1
- csi-node-driver-registrar: v2.16.0

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#development-workflow)
* [ ] [Pending release notes](https://github.com/ceph/ceph-csi-operator/blob/main/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.
