### PR TITLE
ci: deduplicate boot device names

### DIFF
--- a/test/scripts/github-action-helper.sh
+++ b/test/scripts/github-action-helper.sh
@@ -34,7 +34,7 @@ function find_extra_block_dev() {
   # NAME="sda15" SIZE="106M" TYPE="part" MOUNTPOINT="/boot/efi" PKNAME="sda"
   # NAME="sdb"   SIZE="75G"  TYPE="disk" MOUNTPOINT=""          PKNAME=""
   # NAME="sdb1"  SIZE="75G"  TYPE="part" MOUNTPOINT="/mnt"      PKNAME="sdb"
-  boot_dev="$(sudo lsblk --noheading --list --output MOUNTPOINT,PKNAME | grep boot | awk '{print $2}')"
+  boot_dev="$(sudo lsblk --noheading --list --output MOUNTPOINT,PKNAME | grep boot | awk '{print $2}'| sort -u)"
   echo "  == find_extra_block_dev(): boot_dev='$boot_dev'" >/dev/stderr # debug in case of future errors
   # --nodeps ignores partitions
   extra_dev="$(sudo lsblk --noheading --list --nodeps --output KNAME | grep -v loop | grep -v "$boot_dev" | head -1)"


### PR DESCRIPTION
When multiple partitions on the same disk have
boot-related mountpoints (e.g. /boot/efi and /boot), the parent device name appears multiple times in
boot_dev. This causes the egrep -v exclusion pattern to contain duplicates like "sda|sda" which, while
functionally correct, is unnecessary.
Add sort -u to produce a clean, deduplicated list.


failed in https://github.com/Rakshith-R/ceph-volsync-plugin/actions/runs/22408064734/job/64873527116

```
++++ find_extra_block_dev
+++++ sudo lsblk
++++ echo 'NAME    MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
sda       8:0    0   75G  0 disk 
├─sda1    8:1    0   74G  0 part /
├─sda14   8:14   0    4M  0 part 
├─sda15   8:15   0  106M  0 part /boot/efi
└─sda16 259:0    0  913M  0 part /boot
sdb       8:16   0   75G  0 disk 
└─sdb1    8:17   0   75G  0 part 
sdc       8:32   0   75G  0 disk '
NAME    MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
sda       8:0    0   75G  0 disk 
├─sda1    8:1    0   74G  0 part /
├─sda14   8:14   0    4M  0 part 
├─sda15   8:15   0  106M  0 part /boot/efi
└─sda16 259:0    0  913M  0 part /boot
sdb       8:16   0   75G  0 disk 
└─sdb1    8:17   0   75G  0 part 
sdc       8:32   0   75G  0 disk 
+++++ sudo lsblk --noheading --list --output MOUNTPOINT,PKNAME
+++++ grep boot
+++++ awk '{print $2}'
++++ boot_dev='sda
sda'
++++ echo '  == find_extra_block_dev(): boot_dev='\''sda
sda'\'''
  == find_extra_block_dev(): boot_dev='sda
sda'
+++++ sudo lsblk --noheading --list --nodeps --output KNAME
+++++ egrep -v '(sda
sda|loop|nbd)'
+++++ head -1
grep: Unmatched ( or \(
++++ extra_dev=
++++ '[' -z '' ']'
```


**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi-operator/blob/main/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.
