### PR TITLE
csi: update ceph-csi image to v3.16.2

### DIFF
--- a/internal/controller/defaults.go
+++ b/internal/controller/defaults.go
@@ -34,7 +34,7 @@ var imageDefaults = map[string]string{
 	"snapshotter":       "registry.k8s.io/sig-storage/csi-snapshotter:v8.5.0",
 	"registrar":         "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0",
 	"snapshot-metadata": "registry.k8s.io/sig-storage/csi-snapshot-metadata:v0.2.0",
-	"plugin":            "quay.io/cephcsi/cephcsi:v3.16.1",
+	"plugin":            "quay.io/cephcsi/cephcsi:v3.16.2",
 	"addons":            "quay.io/csiaddons/k8s-sidecar:v0.14.0",
 }
 


### PR DESCRIPTION


<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi-operator! -->

# Describe what this PR does #

This patch updates the ceph-csi image version to v3.16.2

