### PR TITLE
fix: explicitly set boolean flag values for both true and false

### DIFF
--- a/internal/utils/csi.go
+++ b/internal/utils/csi.go
@@ -424,10 +424,10 @@ func TypeContainerArg(t string) string {
 	}
 }
 func SetMetadataContainerArg(on bool) string {
-	return If(on, "--setmetadata=true", "")
+	return fmt.Sprintf("--setmetadata=%t", on)
 }
 func SetFencingContainerArg(on bool) string {
-	return If(on, "--enable-fencing=true", "")
+	return fmt.Sprintf("--enable-fencing=%t", on)
 }
 func TimeoutContainerArg(timeout int) string {
 	return fmt.Sprintf("--timeout=%ds", timeout)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi-operator! -->

# Describe what this PR does #

```
SetMetadataContainerArg and SetFencingContainerArg returned an empty string when false,
relying on ceph-csi defaults. If ceph-csi changes its defaults, users who explicitly set these to
false in their Driver CR would be silently ignored. Use fmt.Sprintf with %t to always pass the
explicit value.
```

See: https://github.com/ceph/ceph-csi/pull/6218#issuecomment-4211665029

Fixes: https://github.com/ceph/ceph-csi-operator/issues/380

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#development-workflow)
* [ ] [Pending release notes](https://github.com/ceph/ceph-csi-operator/blob/main/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.
