### PR TITLE
deprecate: driver.spec.EnableMetadata field

### DIFF
--- a/api/v1/driver_types.go
+++ b/api/v1/driver_types.go
@@ -291,9 +291,7 @@ type DriverSpec struct {
 	//+kubebuilder:validation:Optional
 	ClusterName *string `json:"clusterName,omitempty"`
 
-	// Set to true to enable adding volume metadata on the CephFS subvolumes and RBD images.
-	// Not all users might be interested in getting volume/snapshot details as metadata on CephFS subvolume and RBD images.
-	// Hence enable metadata is false by default.
+	// Deprecated: This field is no longer used by the ceph-csi driver and will be ignored.
 	//+kubebuilder:validation:Optional
 	EnableMetadata *bool `json:"enableMetadata,omitempty"`
 

--- a/config/crd/bases/csi.ceph.io_drivers.yaml
+++ b/config/crd/bases/csi.ceph.io_drivers.yaml
@@ -3649,10 +3649,8 @@ spec:
                   Fencing is a feature that allows the driver to fence a node when it is tainted with node.kubernetes.io/out-of-service.
                 type: boolean
               enableMetadata:
-                description: |-
-                  Set to true to enable adding volume metadata on the CephFS subvolumes and RBD images.
-                  Not all users might be interested in getting volume/snapshot details as metadata on CephFS subvolume and RBD images.
-                  Hence enable metadata is false by default.
+                description: 'Deprecated: This field is no longer used by the ceph-csi
+                  driver and will be ignored.'
                 type: boolean
               encryption:
                 description: Driver's encryption settings

--- a/config/crd/bases/csi.ceph.io_operatorconfigs.yaml
+++ b/config/crd/bases/csi.ceph.io_operatorconfigs.yaml
@@ -3687,10 +3687,8 @@ spec:
                       Fencing is a feature that allows the driver to fence a node when it is tainted with node.kubernetes.io/out-of-service.
                     type: boolean
                   enableMetadata:
-                    description: |-
-                      Set to true to enable adding volume metadata on the CephFS subvolumes and RBD images.
-                      Not all users might be interested in getting volume/snapshot details as metadata on CephFS subvolume and RBD images.
-                      Hence enable metadata is false by default.
+                    description: 'Deprecated: This field is no longer used by the
+                      ceph-csi driver and will be ignored.'
                     type: boolean
                   encryption:
                     description: Driver's encryption settings

--- a/deploy/all-in-one/install.yaml
+++ b/deploy/all-in-one/install.yaml
@@ -4200,10 +4200,8 @@ spec:
                   Fencing is a feature that allows the driver to fence a node when it is tainted with node.kubernetes.io/out-of-service.
                 type: boolean
               enableMetadata:
-                description: |-
-                  Set to true to enable adding volume metadata on the CephFS subvolumes and RBD images.
-                  Not all users might be interested in getting volume/snapshot details as metadata on CephFS subvolume and RBD images.
-                  Hence enable metadata is false by default.
+                description: 'Deprecated: This field is no longer used by the ceph-csi
+                  driver and will be ignored.'
                 type: boolean
               encryption:
                 description: Driver's encryption settings
@@ -18583,10 +18581,8 @@ spec:
                       Fencing is a feature that allows the driver to fence a node when it is tainted with node.kubernetes.io/out-of-service.
                     type: boolean
                   enableMetadata:
-                    description: |-
-                      Set to true to enable adding volume metadata on the CephFS subvolumes and RBD images.
-                      Not all users might be interested in getting volume/snapshot details as metadata on CephFS subvolume and RBD images.
-                      Hence enable metadata is false by default.
+                    description: 'Deprecated: This field is no longer used by the
+                      ceph-csi driver and will be ignored.'
                     type: boolean
                   encryption:
                     description: Driver's encryption settings

--- a/deploy/charts/ceph-csi-drivers/values.yaml
+++ b/deploy/charts/ceph-csi-drivers/values.yaml
@@ -54,8 +54,6 @@ operatorConfig:
       name: ""
     # -- Cluster name identifier (default: "")
     clusterName: ""
-    # -- Flag to enable metadata (default: false)
-    enableMetadata: false
     # -- gRPC timeout in seconds (default: 30)
     grpcTimeout: 30
     # -- Snapshot policy (options: none, volumeGroupSnapshot, volumeSnapshot) (default: "none")
@@ -141,8 +139,6 @@ drivers:
       name: ""
     # -- Cluster name identifier (default: "")
     clusterName: ""
-    # -- Flag to enable metadata (default: false)
-    enableMetadata: false
     # -- gRPC timeout in seconds (default: 30)
     grpcTimeout: 30
     # -- Snapshot policy (options: none, volumeGroupSnapshot, volumeSnapshot) (default: "none")
@@ -218,8 +214,6 @@ drivers:
       name: ""
     # -- Cluster name identifier (default: "")
     clusterName: ""
-    # -- Flag to enable metadata (default: false)
-    enableMetadata: false
     # -- gRPC timeout in seconds (default: 30)
     grpcTimeout: 30
     # -- Snapshot policy (options: none, volumeGroupSnapshot, volumeSnapshot) (default: "none")
@@ -295,8 +289,6 @@ drivers:
       name: ""
     # -- Cluster name identifier (default: "")
     clusterName: ""
-    # -- Flag to enable metadata (default: false)
-    enableMetadata: false
     # -- gRPC timeout in seconds (default: 30)
     grpcTimeout: 30
     # -- Snapshot policy (options: none, volumeGroupSnapshot, volumeSnapshot) (default: "volumeSnapshot")
@@ -372,8 +364,6 @@ drivers:
       name: ""
     # -- Cluster name identifier (default: "")
     clusterName: ""
-    # -- Flag to enable metadata (default: false)
-    enableMetadata: false
     # -- gRPC timeout in seconds (default: 30)
     grpcTimeout: 30
     # -- Snapshot policy (options: none, volumeGroupSnapshot, volumeSnapshot) (default: "volumeSnapshot")

--- a/deploy/charts/ceph-csi-operator/templates/driver-crd.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/driver-crd.yaml
@@ -3646,10 +3646,8 @@ spec:
                   Fencing is a feature that allows the driver to fence a node when it is tainted with node.kubernetes.io/out-of-service.
                 type: boolean
               enableMetadata:
-                description: |-
-                  Set to true to enable adding volume metadata on the CephFS subvolumes and RBD images.
-                  Not all users might be interested in getting volume/snapshot details as metadata on CephFS subvolume and RBD images.
-                  Hence enable metadata is false by default.
+                description: 'Deprecated: This field is no longer used by the ceph-csi
+                  driver and will be ignored.'
                 type: boolean
               encryption:
                 description: Driver's encryption settings

--- a/deploy/charts/ceph-csi-operator/templates/operatorconfig-crd.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/operatorconfig-crd.yaml
@@ -3676,10 +3676,8 @@ spec:
                       Fencing is a feature that allows the driver to fence a node when it is tainted with node.kubernetes.io/out-of-service.
                     type: boolean
                   enableMetadata:
-                    description: |-
-                      Set to true to enable adding volume metadata on the CephFS subvolumes and RBD images.
-                      Not all users might be interested in getting volume/snapshot details as metadata on CephFS subvolume and RBD images.
-                      Hence enable metadata is false by default.
+                    description: 'Deprecated: This field is no longer used by the ceph-csi
+                      driver and will be ignored.'
                     type: boolean
                   encryption:
                     description: Driver's encryption settings

--- a/deploy/multifile/crd.yaml
+++ b/deploy/multifile/crd.yaml
@@ -4191,10 +4191,8 @@ spec:
                   Fencing is a feature that allows the driver to fence a node when it is tainted with node.kubernetes.io/out-of-service.
                 type: boolean
               enableMetadata:
-                description: |-
-                  Set to true to enable adding volume metadata on the CephFS subvolumes and RBD images.
-                  Not all users might be interested in getting volume/snapshot details as metadata on CephFS subvolume and RBD images.
-                  Hence enable metadata is false by default.
+                description: 'Deprecated: This field is no longer used by the ceph-csi
+                  driver and will be ignored.'
                 type: boolean
               encryption:
                 description: Driver's encryption settings
@@ -18574,10 +18572,8 @@ spec:
                       Fencing is a feature that allows the driver to fence a node when it is tainted with node.kubernetes.io/out-of-service.
                     type: boolean
                   enableMetadata:
-                    description: |-
-                      Set to true to enable adding volume metadata on the CephFS subvolumes and RBD images.
-                      Not all users might be interested in getting volume/snapshot details as metadata on CephFS subvolume and RBD images.
-                      Hence enable metadata is false by default.
+                    description: 'Deprecated: This field is no longer used by the
+                      ceph-csi driver and will be ignored.'
                     type: boolean
                   encryption:
                     description: Driver's encryption settings

--- a/docs/helm-charts/drivers-chart.md
+++ b/docs/helm-charts/drivers-chart.md
@@ -67,7 +67,6 @@ The following table lists the configurable parameters of the ceph-csi-drivers ch
 | `drivers.cephfs.controllerPlugin.resources` | Resource requirements for controller plugin containers (default: {}) | `{}` |
 | `drivers.cephfs.controllerPlugin.tolerations` | List of tolerations for the controller plugin (default: []) | `[]` |
 | `drivers.cephfs.deployCsiAddons` | Flag to deploy CSI Addons (default: false) | `false` |
-| `drivers.cephfs.enableMetadata` | Flag to enable metadata (default: false) | `false` |
 | `drivers.cephfs.enabled` | Enable the CephFS driver (default: true) | `true` |
 | `drivers.cephfs.encryption.configMapRef.name` | Name of the ConfigMap for encryption settings (default: "") | `""` |
 | `drivers.cephfs.fsGroupPolicy` | File system group policy (e.g., "None", "ReadWriteOnceWithFSType") (default: "None") | `"None"` |
@@ -100,7 +99,6 @@ The following table lists the configurable parameters of the ceph-csi-drivers ch
 | `drivers.nfs.controllerPlugin.resources` | Resource requirements for controller plugin containers (default: {}) | `{}` |
 | `drivers.nfs.controllerPlugin.tolerations` | List of tolerations for the controller plugin (default: []) | `[]` |
 | `drivers.nfs.deployCsiAddons` | Flag to deploy CSI Addons (default: false) | `false` |
-| `drivers.nfs.enableMetadata` | Flag to enable metadata (default: false) | `false` |
 | `drivers.nfs.enabled` | Enable the NFS driver (default: true) | `true` |
 | `drivers.nfs.encryption.configMapRef.name` | Name of the ConfigMap for encryption settings (default: "") | `""` |
 | `drivers.nfs.fsGroupPolicy` | File system group policy (e.g., "None", "ReadWriteOnceWithFSType") (default: "None") | `"None"` |
@@ -134,7 +132,6 @@ The following table lists the configurable parameters of the ceph-csi-drivers ch
 | `drivers.nvmeof.controllerPlugin.resources` | Resource requirements for controller plugin containers (default: {}) | `{}` |
 | `drivers.nvmeof.controllerPlugin.tolerations` | List of tolerations for the controller plugin (default: []) | `[]` |
 | `drivers.nvmeof.deployCsiAddons` | Flag to deploy CSI Addons (default: false) | `false` |
-| `drivers.nvmeof.enableMetadata` | Flag to enable metadata (default: false) | `false` |
 | `drivers.nvmeof.enabled` | Enable the NVMe-oF driver (default: true) | `true` |
 | `drivers.nvmeof.encryption.configMapRef.name` | Name of the ConfigMap for encryption settings (default: "") | `""` |
 | `drivers.nvmeof.fsGroupPolicy` | File system group policy (e.g., "None", "ReadWriteOnceWithFSType") (default: "File") | `"File"` |
@@ -167,7 +164,6 @@ The following table lists the configurable parameters of the ceph-csi-drivers ch
 | `drivers.rbd.controllerPlugin.resources` | Resource requirements for controller plugin containers (default: {}) | `{}` |
 | `drivers.rbd.controllerPlugin.tolerations` | List of tolerations for the controller plugin (default: []) | `[]` |
 | `drivers.rbd.deployCsiAddons` | Flag to deploy CSI Addons (default: false) | `false` |
-| `drivers.rbd.enableMetadata` | Flag to enable metadata (default: false) | `false` |
 | `drivers.rbd.enabled` | Enable the RBD driver (default: true) | `true` |
 | `drivers.rbd.encryption.configMapRef.name` | Name of the ConfigMap for encryption settings (default: "") | `""` |
 | `drivers.rbd.fsGroupPolicy` | File system group policy (e.g., "None", "ReadWriteOnceWithFSType") (default: "File") | `"File"` |
@@ -204,7 +200,6 @@ The following table lists the configurable parameters of the ceph-csi-drivers ch
 | `operatorConfig.driverSpecDefaults.controllerPlugin.resources` | Resource requirements for controller plugin containers (default: {}) | `{}` |
 | `operatorConfig.driverSpecDefaults.controllerPlugin.tolerations` | List of tolerations for the controller plugin (default: []) | `[]` |
 | `operatorConfig.driverSpecDefaults.deployCsiAddons` | Flag to deploy CSI Addons (default: false) | `false` |
-| `operatorConfig.driverSpecDefaults.enableMetadata` | Flag to enable metadata (default: false) | `false` |
 | `operatorConfig.driverSpecDefaults.encryption.configMapRef.name` | Name of the ConfigMap for encryption settings (default: "") | `""` |
 | `operatorConfig.driverSpecDefaults.fsGroupPolicy` | File system group policy (e.g., "None", "ReadWriteOnceWithFSType") (default: "File") | `"File"` |
 | `operatorConfig.driverSpecDefaults.fuseMountOptions` | FUSE mount options (default: {}) | `{}` |

--- a/internal/controller/driver_controller.go
+++ b/internal/controller/driver_controller.go
@@ -622,7 +622,6 @@ func (r *driverReconcile) reconcileControllerPluginDeployment() error {
 										utils.ControllerServerContainerArg,
 										utils.DriverNameContainerArg(r.driver.Name),
 										utils.PidlimitContainerArg,
-										utils.SetMetadataContainerArg(ptr.Deref(r.driver.Spec.EnableMetadata, false)),
 										utils.SetFencingContainerArg(ptr.Deref(r.driver.Spec.EnableFencing, false)),
 										utils.ClusterNameContainerArg(ptr.Deref(r.driver.Spec.ClusterName, "")),
 										utils.If(forceKernelClient, utils.ForceCephKernelClientContainerArg, ""),
@@ -881,7 +880,6 @@ func (r *driverReconcile) reconcileControllerPluginDeployment() error {
 										utils.TypeContainerArg("controller"),
 										utils.DriverNamespaceContainerArg,
 										utils.DriverNameContainerArg(r.driver.Name),
-										utils.SetMetadataContainerArg(ptr.Deref(r.driver.Spec.EnableMetadata, false)),
 										utils.ClusterNameContainerArg(ptr.Deref(r.driver.Spec.ClusterName, "")),
 									},
 								),
@@ -1703,9 +1701,6 @@ func mergeDriverSpecs(dest, src *csiv1.DriverSpec) {
 	}
 	if dest.ClusterName == nil {
 		dest.ClusterName = src.ClusterName
-	}
-	if dest.EnableMetadata == nil {
-		dest.EnableMetadata = src.EnableMetadata
 	}
 	if dest.GRpcTimeout == 0 {
 		dest.GRpcTimeout = src.GRpcTimeout

--- a/internal/utils/csi.go
+++ b/internal/utils/csi.go
@@ -423,9 +423,6 @@ func TypeContainerArg(t string) string {
 		return ""
 	}
 }
-func SetMetadataContainerArg(on bool) string {
-	return fmt.Sprintf("--setmetadata=%t", on)
-}
 func SetFencingContainerArg(on bool) string {
 	return fmt.Sprintf("--enable-fencing=%t", on)
 }

--- a/vendor/github.com/ceph/ceph-csi-operator/api/v1/driver_types.go
+++ b/vendor/github.com/ceph/ceph-csi-operator/api/v1/driver_types.go
@@ -291,9 +291,7 @@ type DriverSpec struct {
 	//+kubebuilder:validation:Optional
 	ClusterName *string `json:"clusterName,omitempty"`
 
-	// Set to true to enable adding volume metadata on the CephFS subvolumes and RBD images.
-	// Not all users might be interested in getting volume/snapshot details as metadata on CephFS subvolume and RBD images.
-	// Hence enable metadata is false by default.
+	// Deprecated: This field is no longer used by the ceph-csi driver and will be ignored.
 	//+kubebuilder:validation:Optional
 	EnableMetadata *bool `json:"enableMetadata,omitempty"`
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi-operator! -->

# Describe what this PR does #

```
The EnableMetadata field and --setmetadata flag are no longer used
by the ceph-csi driver. Remove the field from the DriverSpec API,
generated deepcopy, CRD manifests, and Helm chart values/templates.
```

See: https://github.com/ceph/ceph-csi/pull/6225

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#development-workflow)
* [ ] [Pending release notes](https://github.com/ceph/ceph-csi-operator/blob/main/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.
