### PR TITLE
doc: update the document for sc and secret

### DIFF
--- a/docs/kubernetes-installation.md
+++ b/docs/kubernetes-installation.md
@@ -19,7 +19,11 @@
   - [4. Verify Installation](#4-verify-installation)
   - [5. Create CephConnection](#5-create-cephconnection)
   - [6. Create ClientProfile](#6-create-clientprofile)
-  - [6. Upgrade Ceph-CSI Operator and Drivers](#6-upgrade-ceph-csi-operator-and-drivers)
+  - [7. Create Ceph Secrets](#7-create-ceph-secrets)
+  - [8. Create StorageClasses](#8-create-storageclasses)
+  - [9. Create VolumeSnapshotClasses (Optional)](#9-create-volumesnapshotclasses-optional)
+  - [10. Verify Storage Provisioning](#10-verify-storage-provisioning)
+  - [11. Upgrade Ceph-CSI Operator and Drivers](#11-upgrade-ceph-csi-operator-and-drivers)
     - [Step 1: Checkout the Latest Tag](#step-1-checkout-the-latest-tag)
       - [Step 2: Apply the updated yaml's](#step-2-apply-the-updated-yamls)
       - [Step 3: Verify the Upgrade](#step-3-verify-the-upgrade)
@@ -220,10 +224,71 @@ spec:
 ' | kubectl create -f -
 ```
 
-Use the ClientProfile Name as the ClusterID in the required classes (StrorageClass,VolumeSnapshotClass etc).
+> [!IMPORTANT]
+> The ClientProfile name (`storage` in this example) will be used as the `clusterID` parameter in your StorageClass and VolumeSnapshotClass resources.
 
+## 7. Create Ceph Secrets
 
-## 6. Upgrade Ceph-CSI Operator and Drivers
+Before you can provision storage, create Kubernetes Secrets containing Ceph credentials for CSI operations.
+
+For detailed instructions on creating Ceph users and Kubernetes Secrets, refer to the upstream Ceph-CSI documentation:
+
+- **Secret Examples**:
+  - [RBD Secret Example](https://github.com/ceph/ceph-csi/blob/devel/examples/rbd/secret.yaml)
+  - [CephFS Secret Example](https://github.com/ceph/ceph-csi/blob/devel/examples/cephfs/secret.yaml) (also used for NFS)
+- **Ceph Capabilities**: [Required Ceph Capabilities](https://github.com/ceph/ceph-csi/blob/devel/docs/capabilities.md)
+
+> [!NOTE]
+> - Create secrets in the namespace where your applications will create PVCs
+> - NFS volumes use the same CephFS secret format since NFS is built on CephFS
+
+## 8. Create StorageClasses
+
+Create StorageClasses using the upstream Ceph-CSI examples:
+
+- [RBD StorageClass Example](https://github.com/ceph/ceph-csi/blob/devel/examples/rbd/storageclass.yaml)
+- [CephFS StorageClass Example](https://github.com/ceph/ceph-csi/blob/devel/examples/cephfs/storageclass.yaml)
+- [NFS StorageClass Example](https://github.com/ceph/ceph-csi/blob/devel/examples/nfs/storageclass.yaml)
+
+> [!IMPORTANT]
+> **ClusterID and ClientProfile Mapping**
+>
+> The `clusterID` parameter **must match** your ClientProfile CR name:
+>
+> ```yaml
+> # In your StorageClass
+> parameters:
+>   clusterID: storage  # Must match the ClientProfile name from step 6
+> ```
+>
+> This is the key difference from legacy Ceph-CSI deployments where `clusterID` was arbitrary.
+
+## 9. Create VolumeSnapshotClasses (Optional)
+
+For snapshot support, use the upstream Ceph-CSI VolumeSnapshotClass examples:
+
+- [RBD VolumeSnapshotClass Example](https://github.com/ceph/ceph-csi/blob/devel/examples/rbd/snapshotclass.yaml)
+- [CephFS VolumeSnapshotClass Example](https://github.com/ceph/ceph-csi/blob/devel/examples/cephfs/snapshotclass.yaml)
+- [NFS VolumeSnapshotClass Example](https://github.com/ceph/ceph-csi/blob/devel/examples/nfs/snapshotclass.yaml)
+
+Ensure the `clusterID` parameter matches your ClientProfile name:
+
+```yaml
+parameters:
+  clusterID: storage  # Must match your ClientProfile name
+```
+
+## 10. Verify Storage Provisioning
+
+Test your setup using the [Ceph-CSI PVC examples](https://github.com/ceph/ceph-csi/tree/devel/examples):
+
+- [RBD PVC Example](https://github.com/ceph/ceph-csi/blob/devel/examples/rbd/pvc.yaml)
+- [CephFS PVC Example](https://github.com/ceph/ceph-csi/blob/devel/examples/cephfs/pvc.yaml)
+- [NFS PVC Example](https://github.com/ceph/ceph-csi/blob/devel/examples/nfs/pvc.yaml)
+
+The PVC should reach `Bound` status, indicating successful provisioning.
+
+## 11. Upgrade Ceph-CSI Operator and Drivers
 
 Upgrading your Ceph-CSI installation involves updating the Ceph-CSI Operator and drivers to a newer version. Follow the steps below to perform the upgrade:
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -17,23 +17,43 @@ Ceph-CSI v3.16+ officially recommends using Ceph-CSI-Operator as the supported d
 
 
 > [!WARNING]
-> Important Warning (Read Before Proceeding)
-
-**After removing the existing Ceph-CSI components, new Pods cannot mount PVCs, and new PVCs or VolumeSnapshots cannot be created until migration is completed.
-Existing Pods using RBD/CephFS kernel mounter will continue to work, as long as they are not restarted.
-Any Pod that restarts or gets rescheduled before the new CSI driver is running will fail to mount volumes.
-Plan maintenance windows accordingly.**
-
-> [!WARNING]
-> The **Ceph-CSI-Operator does *not* automatically create StorageClasses or VolumeSnapshotClasses**.
+> **Critical Migration Constraints**
 >
-> Legacy Ceph-CSI Helm charts provided automated creation of these objects, but the operator does not include this functionality.
+> **1. Existing PersistentVolumes and Secret Namespace:**
+>
+> Existing PersistentVolumes contain **immutable** references to secrets in the old namespace (e.g., `ceph-csi`). These secret references **cannot** be changed after a PV is created.
+>
+> This means:
+> - You **MUST keep** the old CSI secrets in the original namespace (e.g., `ceph-csi`)
+> - You **CANNOT** delete the old namespace where secrets are referenced
+> - Existing volumes will **FAIL to mount** if the old secrets are deleted
+>
+> **2. Migration Downtime:**
+>
+> After removing existing Ceph-CSI components:
+> - New Pods cannot mount PVCs until migration is completed
+> - New PVCs or VolumeSnapshots cannot be created until drivers are running
+> - Existing Pods using RBD/CephFS kernel mounter will continue to work (as long as they are not restarted)
+> - Any Pod that restarts or gets rescheduled before the new CSI driver is running will fail to mount volumes
+>
+> **Plan maintenance windows accordingly.**
 
 
 
 ## Common Preparation Steps (Applies to Both YAML & Helm Tracks)
 
-### Backup the existing Ceph-CSI configuration if you have any
+### Identify Your Existing Configuration
+
+Before migrating, identify the `clusterID` used in your existing StorageClasses:
+
+```bash
+# View your existing StorageClass to find the clusterID
+kubectl get storageclass <your-storageclass-name> -o yaml | grep clusterID
+```
+
+Note the `clusterID` value - you'll use this exact name for your ClientProfile.
+
+### Backup the existing Ceph-CSI configuration
 
 ```bash
 mkdir -p backup/ceph-csi
@@ -41,7 +61,6 @@ kubectl get configmap -n ceph-csi -o yaml > backup/ceph-csi/configmap.yaml
 kubectl get deployment,daemonset -n ceph-csi -o yaml > backup/ceph-csi/workloads.yaml
 kubectl get serviceaccount,role,rolebinding -n ceph-csi -o yaml > backup/ceph-csi/rbac.yaml
 kubectl get csidriver -oyaml > backup/ceph-csi/csidriver.yaml
-
 ```
 
 **Note:** Replace the namespace where ceph-CSI resources are created.
@@ -76,11 +95,12 @@ helm uninstall ceph-csi -n ceph-csi
 
 ### Install the Ceph-CSI-Operator
 
-Follow the official [Installation Guide](installation.md) to deploy and configure the Ceph-CSI-Operator.
+Install the operator using the [Installation Guide](installation.md) (stop before the "Create Ceph Secrets" section).
 
-After installing the operator and creating the required CR (Drivers,CephConnection,ClientProfiles)
-
-Ensure the CR definitions include fields that match your previous Ceph-CSI configuration (monitors, pools etc)
+You will need to:
+1. Install the operator
+2. Deploy the CSI drivers (RBD, CephFS, NFS as needed)
+3. Create CephConnection and ClientProfile CRs (see below)
 
 > [!WARNING]
 >  Important Migration Note for `ClusterID` Handling
@@ -93,24 +113,180 @@ In legacy deployments, `clusterID` is defined in:
 
 In the operator-based deployments, these must be represented through a ClientProfile CR.
 
-### Requirement: ClientProfile CR
+## Create CephConnection and ClientProfile
 
-You must create a ClientProfile whose name matches the old `clusterID`, because:
+### Step 1: Extract Configuration from Existing Setup
 
-- StorageClasses and SnapshotClasses will reference the ClientProfile name.
+First, extract the Ceph monitor addresses from your existing ConfigMap:
 
-For example the `clusterID` was `ceph-csi` the ClientProfile CR looks like below
+```bash
+# View your existing ceph-csi ConfigMap
+kubectl get configmap ceph-csi-config -n ceph-csi -o yaml
+```
+
+The ConfigMap contains monitor addresses under the `config.json` key.
+
+### Step 2: Create CephConnection
+
+Create a CephConnection using the monitor addresses from your existing ConfigMap:
+
+```yaml
+apiVersion: csi.ceph.io/v1
+kind: CephConnection
+metadata:
+  name: ceph-connection
+  namespace: ceph-csi-operator-system
+spec:
+  monitors:
+    - <monitor-1>:6789  # From your existing ceph-csi ConfigMap
+    - <monitor-2>:6789
+    - <monitor-3>:6789
+```
+
+### Step 3: Create ClientProfile with Matching ClusterID
+
+Create a ClientProfile with a name that **exactly matches** the `clusterID` from your existing StorageClass:
 
 ```yaml
 apiVersion: csi.ceph.io/v1
 kind: ClientProfile
 metadata:
-  name: ceph-csi #change this with your clusterID
+  name: my-ceph-cluster  # Must match the clusterID from your existing StorageClass
   namespace: ceph-csi-operator-system
 spec:
   cephConnectionRef:
     name: ceph-connection
-  ...
+  cephFs:
+    subVolumeGroup: csi  # Match your existing CephFS configuration
+  rbd:
+    radosNamespace: ""  # Match your existing RBD configuration
 ```
 
-Once all the pods are up and running, the migration is complete. We can delete the backup files now.
+> [!IMPORTANT]
+> **ClusterID Matching is Critical**
+>
+> The ClientProfile name **must exactly match** the `clusterID` value in your existing StorageClasses. This allows your existing StorageClasses to work seamlessly with the operator without modification.
+
+## Understanding Secret Namespace Requirements During Migration
+
+### The Secret Namespace Challenge
+
+When you create a PersistentVolume using CSI, Kubernetes stores secret references directly in the PV object's spec. These fields are **immutable** and include:
+
+- `spec.csi.nodeStageSecretRef` - Used when mounting the volume on a node
+- `spec.csi.controllerExpandSecretRef` - Used when expanding the volume
+
+Example from an existing PV:
+```yaml
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pvc-12345678-abcd-1234-5678-123456789012
+spec:
+  csi:
+    driver: rbd.csi.ceph.com
+    nodeStageSecretRef:
+      name: csi-rbd-secret
+      namespace: ceph-csi  # This cannot be changed!
+    controllerExpandSecretRef:
+      name: csi-rbd-secret
+      namespace: ceph-csi  # This cannot be changed!
+```
+
+### Required Actions
+
+> [!IMPORTANT]
+> **You MUST Keep Old Secrets in Their Original Namespace**
+>
+> **For Existing PersistentVolumes:**
+> - Existing PVs reference secrets in the old namespace (e.g., `ceph-csi`)
+> - These references **cannot be modified** after the PV is created
+> - You **MUST keep** these secrets in the original namespace
+> - **DO NOT** delete the old namespace or these secrets
+> - If you delete these secrets, existing volumes will fail to mount with errors like:
+>   ```text
+>   failed to find the secret csi-rbd-secret in the namespace ceph-csi
+>   ```
+>
+> **For New PersistentVolumes:**
+> - New PVCs can use secrets in any namespace
+> - The namespace is specified in your StorageClass parameters
+
+### Migration Strategy Options
+
+#### Option 1: Keep Everything in the Old Namespace (Simplest)
+
+Continue using your existing StorageClasses and secrets:
+- Keep secrets in the old namespace (e.g., `ceph-csi`)
+- Keep using existing StorageClasses
+- Both old and new PVs will use secrets from the old namespace
+
+#### Option 2: Create New StorageClasses for New Workloads
+
+For new applications, create new StorageClasses that reference secrets in a different namespace:
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ceph-rbd-operator  # New StorageClass name
+provisioner: rbd.csi.ceph.com
+parameters:
+  clusterID: my-ceph-cluster
+  pool: replicapool
+  imageFeatures: layering
+  # New secrets in a different namespace
+  csi.storage.k8s.io/provisioner-secret-name: csi-rbd-secret
+  csi.storage.k8s.io/provisioner-secret-namespace: ceph-csi-operator-system
+  csi.storage.k8s.io/node-stage-secret-name: csi-rbd-secret
+  csi.storage.k8s.io/node-stage-secret-namespace: ceph-csi-operator-system
+  # ... other secret parameters
+```
+
+With this approach:
+- Old PVCs/PVs continue using secrets from the old namespace
+- New PVCs can use the new StorageClass with secrets in the new namespace
+- You still cannot delete the old namespace until all old PVs are deleted
+
+### Cleanup Limitations
+
+> [!WARNING]
+> **You Cannot Fully Clean Up the Old Namespace**
+>
+> As long as you have existing PersistentVolumes created by the old ceph-csi deployment:
+> - You **cannot** delete the old namespace (e.g., `ceph-csi`)
+> - You **cannot** delete the CSI secrets in that namespace
+> - These resources must remain until:
+>   1. All pods using old PVs are deleted
+>   2. All old PVCs are deleted
+>   3. All old PVs are deleted
+>
+> This is a limitation of Kubernetes CSI, not the ceph-csi-operator.
+
+## 7. Verify the Migration
+
+Once all the operator pods are up and running, verify the migration:
+
+```bash
+# Check operator and driver pods
+kubectl get pods -n ceph-csi-operator-system
+
+# Verify existing PVCs remain bound
+kubectl get pvc --all-namespaces
+
+# Test new provisioning with existing StorageClass
+kubectl create -f <test-pvc.yaml>
+```
+
+The migration is complete when:
+- All CSI driver pods are running
+- Existing PVCs remain in `Bound` status
+- New PVCs can be provisioned successfully
+
+## 8. Clean Up
+
+Once all the pods are up and running and you've verified that storage provisioning works correctly, the migration is complete. You can now delete the backup files:
+
+```bash
+rm -rf backup/
+```

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -8,7 +8,11 @@
   - [4. Verify Installation](#4-verify-installation)
   - [5. Create CephConnection](#5-create-cephconnection)
   - [6. Create ClientProfile](#6-create-clientprofile)
-  - [7. Clean Up Resources](#7-clean-up-resources)
+  - [7. Create Ceph Secrets](#7-create-ceph-secrets)
+  - [8. Create StorageClasses](#8-create-storageclasses)
+  - [9. Create VolumeSnapshotClasses (Optional)](#9-create-volumesnapshotclasses-optional)
+  - [10. Test Storage Provisioning](#10-test-storage-provisioning)
+  - [11. Clean Up Resources](#11-clean-up-resources)
 
 # Quick Start Guide for Ceph-CSI-Operator
 
@@ -129,10 +133,69 @@ spec:
 ' | kubectl create -f -
 ```
 
-Use the ClientProfile Name as the ClusterID in the required classes (StrorageClass,VolumeSnapshotClass etc).
+> [!IMPORTANT]
+> The ClientProfile name (`storage` in this example) will be used as the `clusterID` parameter in your StorageClass and VolumeSnapshotClass resources.
 
+## 7. Create Ceph Secrets
 
-## 7. Clean Up Resources
+Before creating storage classes, create Kubernetes Secrets with Ceph credentials for CSI operations.
+
+For detailed instructions on creating Ceph users and Kubernetes Secrets, refer to the upstream Ceph-CSI documentation:
+
+- **Secret Examples**:
+  - [RBD Secret Example](https://github.com/ceph/ceph-csi/blob/devel/examples/rbd/secret.yaml)
+  - [CephFS Secret Example](https://github.com/ceph/ceph-csi/blob/devel/examples/cephfs/secret.yaml) (also used for NFS)
+- **Ceph Capabilities**: [Required Ceph Capabilities](https://github.com/ceph/ceph-csi/blob/devel/docs/capabilities.md)
+
+> [!NOTE]
+> - Create secrets in the namespace where your applications will create PVCs
+> - NFS volumes use the same CephFS secret format since NFS is built on CephFS
+
+## 8. Create StorageClasses
+
+Create StorageClasses using the upstream Ceph-CSI examples:
+
+- [RBD StorageClass Example](https://github.com/ceph/ceph-csi/blob/devel/examples/rbd/storageclass.yaml)
+- [CephFS StorageClass Example](https://github.com/ceph/ceph-csi/blob/devel/examples/cephfs/storageclass.yaml)
+- [NFS StorageClass Example](https://github.com/ceph/ceph-csi/blob/devel/examples/nfs/storageclass.yaml)
+
+> [!IMPORTANT]
+> **ClusterID and ClientProfile Mapping**
+>
+> The `clusterID` parameter **must match** your ClientProfile CR name:
+>
+> ```yaml
+> # In your StorageClass
+> parameters:
+>   clusterID: storage  # Must match the ClientProfile name from step 6
+> ```
+
+## 9. Create VolumeSnapshotClasses (Optional)
+
+For snapshot support, use the upstream Ceph-CSI VolumeSnapshotClass examples:
+
+- [RBD VolumeSnapshotClass Example](https://github.com/ceph/ceph-csi/blob/devel/examples/rbd/snapshotclass.yaml)
+- [CephFS VolumeSnapshotClass Example](https://github.com/ceph/ceph-csi/blob/devel/examples/cephfs/snapshotclass.yaml)
+- [NFS VolumeSnapshotClass Example](https://github.com/ceph/ceph-csi/blob/devel/examples/nfs/snapshotclass.yaml)
+
+Ensure the `clusterID` parameter matches your ClientProfile name:
+
+```yaml
+parameters:
+  clusterID: storage  # Must match your ClientProfile name
+```
+
+## 10. Test Storage Provisioning
+
+Test your setup using the [Ceph-CSI PVC examples](https://github.com/ceph/ceph-csi/tree/devel/examples):
+
+- [RBD PVC Example](https://github.com/ceph/ceph-csi/blob/devel/examples/rbd/pvc.yaml)
+- [CephFS PVC Example](https://github.com/ceph/ceph-csi/blob/devel/examples/cephfs/pvc.yaml)
+- [NFS PVC Example](https://github.com/ceph/ceph-csi/blob/devel/examples/nfs/pvc.yaml)
+
+The PVC should reach `Bound` status, indicating successful provisioning.
+
+## 11. Clean Up Resources
 
 To clean up the resources, delete the cepconnection, clientprofile and drivers:
 


### PR DESCRIPTION
Updating the existing document to make things more clear to the migration and also point to the cephcsi repo for secrets and classes.

fixes: #400 
fixes: #433 



