### PR TITLE
helm: add enableFencing para to ceph-csi-driver chart

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -5,5 +5,6 @@
 ## Features
 
 - Added `containerExtraArgs` field to `NodePluginSpec` and `ControllerPluginSpec` to allow passing custom arguments to CSI containers. The field accepts a map where the key is the container name (e.g., `csi-rbdplugin`, `csi-provisioner`, `driver-registrar`) and the value is a list of CLI arguments. This enables customization of container behavior without modifying default operator values. The field can be configured at both the OperatorConfig level (for defaults) and Driver level (for driver-specific overrides).
+- Fencing can now be enabled in the ceph-csi-drivers Helm chart either globally for all drivers or on a per-driver basis.
 
 ## NOTE

--- a/deploy/charts/ceph-csi-drivers/templates/driver.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/driver.yaml
@@ -32,6 +32,7 @@ spec:
   clusterName: {{ $driver.clusterName }}
   {{- end }}
   enableMetadata: {{ $driver.enableMetadata }}
+  enableFencing: {{ $driver.enableFencing }}
   grpcTimeout: {{ $driver.grpcTimeout }}
   snapshotPolicy: {{ $driver.snapshotPolicy }}
   generateOMapInfo: {{ $driver.generateOMapInfo }}

--- a/deploy/charts/ceph-csi-drivers/templates/operatorConfig.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/operatorConfig.yaml
@@ -36,6 +36,7 @@ spec:
     clusterName: {{ $config.driverSpecDefaults.clusterName }}
     {{- end }}
     enableMetadata: {{ $config.driverSpecDefaults.enableMetadata }}
+    enableFencing: {{ $config.driverSpecDefaults.enableFencing }}
     grpcTimeout: {{ $config.driverSpecDefaults.grpcTimeout }}
     snapshotPolicy: {{ $config.driverSpecDefaults.snapshotPolicy }}
     generateOMapInfo: {{ $config.driverSpecDefaults.generateOMapInfo }}

--- a/deploy/charts/ceph-csi-drivers/values.yaml
+++ b/deploy/charts/ceph-csi-drivers/values.yaml
@@ -54,6 +54,8 @@ operatorConfig:
       name: ""
     # -- Cluster name identifier (default: "")
     clusterName: ""
+    # -- Flag to enable fencing (default: false)
+    enableFencing: false
     # -- gRPC timeout in seconds (default: 30)
     grpcTimeout: 30
     # -- Snapshot policy (options: none, volumeGroupSnapshot, volumeSnapshot) (default: "none")
@@ -143,6 +145,8 @@ drivers:
       name: ""
     # -- Cluster name identifier (default: "")
     clusterName: ""
+    # -- Flag to enable fencing (default: false)
+    enableFencing: false
     # -- gRPC timeout in seconds (default: 30)
     grpcTimeout: 30
     # -- Snapshot policy (options: none, volumeGroupSnapshot, volumeSnapshot) (default: "none")
@@ -222,6 +226,8 @@ drivers:
       name: ""
     # -- Cluster name identifier (default: "")
     clusterName: ""
+    # -- Flag to enable fencing (default: false)
+    enableFencing: false
     # -- gRPC timeout in seconds (default: 30)
     grpcTimeout: 30
     # -- Snapshot policy (options: none, volumeGroupSnapshot, volumeSnapshot) (default: "none")
@@ -301,6 +307,8 @@ drivers:
       name: ""
     # -- Cluster name identifier (default: "")
     clusterName: ""
+    # -- Flag to enable fencing (default: false)
+    enableFencing: false
     # -- gRPC timeout in seconds (default: 30)
     grpcTimeout: 30
     # -- Snapshot policy (options: none, volumeGroupSnapshot, volumeSnapshot) (default: "volumeSnapshot")
@@ -380,6 +388,8 @@ drivers:
       name: ""
     # -- Cluster name identifier (default: "")
     clusterName: ""
+    # -- Flag to enable fencing (default: false)
+    enableFencing: false
     # -- gRPC timeout in seconds (default: 30)
     grpcTimeout: 30
     # -- Snapshot policy (options: none, volumeGroupSnapshot, volumeSnapshot) (default: "volumeSnapshot")

--- a/docs/helm-charts/drivers-chart.md
+++ b/docs/helm-charts/drivers-chart.md
@@ -87,6 +87,7 @@ The following table lists the configurable parameters of the ceph-csi-drivers ch
 | `drivers.cephfs.controllerPlugin.resources` | Resource requirements for controller plugin containers (default: {}) | `{}` |
 | `drivers.cephfs.controllerPlugin.tolerations` | List of tolerations for the controller plugin (default: []) | `[]` |
 | `drivers.cephfs.deployCsiAddons` | Flag to deploy CSI Addons (default: false) | `false` |
+| `drivers.cephfs.enableFencing` | Flag to enable fencing (default: false) | `false` |
 | `drivers.cephfs.enabled` | Enable the CephFS driver (default: true) | `true` |
 | `drivers.cephfs.encryption.configMapRef.name` | Name of the ConfigMap for encryption settings (default: "") | `""` |
 | `drivers.cephfs.fsGroupPolicy` | File system group policy (e.g., "None", "ReadWriteOnceWithFSType") (default: "None") | `"None"` |
@@ -121,6 +122,7 @@ The following table lists the configurable parameters of the ceph-csi-drivers ch
 | `drivers.nfs.controllerPlugin.resources` | Resource requirements for controller plugin containers (default: {}) | `{}` |
 | `drivers.nfs.controllerPlugin.tolerations` | List of tolerations for the controller plugin (default: []) | `[]` |
 | `drivers.nfs.deployCsiAddons` | Flag to deploy CSI Addons (default: false) | `false` |
+| `drivers.nfs.enableFencing` | Flag to enable fencing (default: false) | `false` |
 | `drivers.nfs.enabled` | Enable the NFS driver (default: true) | `true` |
 | `drivers.nfs.encryption.configMapRef.name` | Name of the ConfigMap for encryption settings (default: "") | `""` |
 | `drivers.nfs.fsGroupPolicy` | File system group policy (e.g., "None", "ReadWriteOnceWithFSType") (default: "None") | `"None"` |
@@ -156,6 +158,7 @@ The following table lists the configurable parameters of the ceph-csi-drivers ch
 | `drivers.nvmeof.controllerPlugin.resources` | Resource requirements for controller plugin containers (default: {}) | `{}` |
 | `drivers.nvmeof.controllerPlugin.tolerations` | List of tolerations for the controller plugin (default: []) | `[]` |
 | `drivers.nvmeof.deployCsiAddons` | Flag to deploy CSI Addons (default: false) | `false` |
+| `drivers.nvmeof.enableFencing` | Flag to enable fencing (default: false) | `false` |
 | `drivers.nvmeof.enabled` | Enable the NVMe-oF driver (default: true) | `true` |
 | `drivers.nvmeof.encryption.configMapRef.name` | Name of the ConfigMap for encryption settings (default: "") | `""` |
 | `drivers.nvmeof.fsGroupPolicy` | File system group policy (e.g., "None", "ReadWriteOnceWithFSType") (default: "File") | `"File"` |
@@ -190,6 +193,7 @@ The following table lists the configurable parameters of the ceph-csi-drivers ch
 | `drivers.rbd.controllerPlugin.resources` | Resource requirements for controller plugin containers (default: {}) | `{}` |
 | `drivers.rbd.controllerPlugin.tolerations` | List of tolerations for the controller plugin (default: []) | `[]` |
 | `drivers.rbd.deployCsiAddons` | Flag to deploy CSI Addons (default: false) | `false` |
+| `drivers.rbd.enableFencing` | Flag to enable fencing (default: false) | `false` |
 | `drivers.rbd.enabled` | Enable the RBD driver (default: true) | `true` |
 | `drivers.rbd.encryption.configMapRef.name` | Name of the ConfigMap for encryption settings (default: "") | `""` |
 | `drivers.rbd.fsGroupPolicy` | File system group policy (e.g., "None", "ReadWriteOnceWithFSType") (default: "File") | `"File"` |
@@ -230,6 +234,7 @@ The following table lists the configurable parameters of the ceph-csi-drivers ch
 | `operatorConfig.driverSpecDefaults.controllerPlugin.resources` | Resource requirements for controller plugin containers (default: {}) | `{}` |
 | `operatorConfig.driverSpecDefaults.controllerPlugin.tolerations` | List of tolerations for the controller plugin (default: []) | `[]` |
 | `operatorConfig.driverSpecDefaults.deployCsiAddons` | Flag to deploy CSI Addons (default: false) | `false` |
+| `operatorConfig.driverSpecDefaults.enableFencing` | Flag to enable fencing (default: false) | `false` |
 | `operatorConfig.driverSpecDefaults.encryption.configMapRef.name` | Name of the ConfigMap for encryption settings (default: "") | `""` |
 | `operatorConfig.driverSpecDefaults.fsGroupPolicy` | File system group policy (e.g., "None", "ReadWriteOnceWithFSType") (default: "File") | `"File"` |
 | `operatorConfig.driverSpecDefaults.fuseMountOptions` | FUSE mount options (default: {}) | `{}` |


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi-operator! -->

# Describe what this PR does #

add enableFencing to the ceph-csi-driver chart configurable on operatorconfig cr as well as on driver cr

## Related issues ##

Fixes: https://github.com/ceph/ceph-csi-operator/issues/379

## Future concerns ##

List items that are not part of the PR and do not impact it's functionality, but are work items that can be taken up subsequently.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#development-workflow)
* [x] [Pending release notes](https://github.com/ceph/ceph-csi-operator/blob/main/PendingReleaseNotes.md)] updated with breaking and/or notable changes for the next major release.
* [x] Documentation has been updated, if necessary.
* [x] Unit tests have been added, if necessary.
* [x] Integration tests have been added, if necessary.
