### PR TITLE
helm: add enabled flag for log rotation in ceph-csi-driver chart

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -6,5 +6,6 @@
 
 - Added `containerExtraArgs` field to `NodePluginSpec` and `ControllerPluginSpec` to allow passing custom arguments to CSI containers. The field accepts a map where the key is the container name (e.g., `csi-rbdplugin`, `csi-provisioner`, `driver-registrar`) and the value is a list of CLI arguments. This enables customization of container behavior without modifying default operator values. The field can be configured at both the OperatorConfig level (for defaults) and Driver level (for driver-specific overrides).
 - Fencing can now be enabled in the ceph-csi-drivers Helm chart either globally for all drivers or on a per-driver basis.
+- Added `enabled` field to log rotation configuration in the ceph-csi-drivers Helm chart. Users can now disable log rotation by setting `log.rotation.enabled: false` either globally in `operatorConfig.driverSpecDefaults` or per-driver in `drivers.<driver-type>`. This resolves Helm warnings when disabling file logging from parent charts.
 
 ## NOTE

--- a/deploy/charts/ceph-csi-drivers/templates/driver.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/driver.yaml
@@ -12,7 +12,7 @@ spec:
   {{- if $driver.log }}
   log:
     verbosity: {{ $driver.log.verbosity }}
-    {{- if $driver.log.rotation }}
+    {{- if and $driver.log.rotation (ne $driver.log.rotation.enabled false) }}
     rotation:
       maxFiles: {{ $driver.log.rotation.maxFiles }}
       maxLogSize: {{ $driver.log.rotation.maxLogSize }}

--- a/deploy/charts/ceph-csi-drivers/templates/operatorConfig.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/operatorConfig.yaml
@@ -16,7 +16,7 @@ spec:
     {{- if $config.driverSpecDefaults.log }}
     log:
       verbosity: {{ $config.driverSpecDefaults.log.verbosity }}
-      {{- if $config.driverSpecDefaults.log.rotation }}
+      {{- if and $config.driverSpecDefaults.log.rotation (ne $config.driverSpecDefaults.log.rotation.enabled false) }}
       rotation:
         maxFiles: {{ $config.driverSpecDefaults.log.rotation.maxFiles }}
         maxLogSize: {{ $config.driverSpecDefaults.log.rotation.maxLogSize }}

--- a/deploy/charts/ceph-csi-drivers/values.yaml
+++ b/deploy/charts/ceph-csi-drivers/values.yaml
@@ -41,6 +41,8 @@ operatorConfig:
       # -- Log verbosity level (0-5) (default: 0)
       verbosity: 0
       rotation:
+        # -- Enable log rotation (default: true)
+        enabled: true
         # -- Maximum number of log files to keep (default: 7)
         maxFiles: 7
         # -- Maximum size of each log file (default: "10Gi")
@@ -132,6 +134,8 @@ drivers:
       # -- Log verbosity level (0-5) (default: 0)
       verbosity: 0
       rotation:
+        # -- Enable log rotation (default: true)
+        enabled: true
         # -- Maximum number of log files to keep (default: 7)
         maxFiles: 7
         # -- Maximum size of each log file (default: "10Gi")
@@ -213,6 +217,8 @@ drivers:
       # -- Log verbosity level (0-5) (default: 0)
       verbosity: 0
       rotation:
+        # -- Enable log rotation (default: true)
+        enabled: true
         # -- Maximum number of log files to keep (default: 7)
         maxFiles: 7
         # -- Maximum size of each log file (default: "10Gi")
@@ -294,6 +300,8 @@ drivers:
       # -- Log verbosity level (0-5) (default: 0)
       verbosity: 0
       rotation:
+        # -- Enable log rotation (default: true)
+        enabled: true
         # -- Maximum number of log files to keep (default: 7)
         maxFiles: 7
         # -- Maximum size of each log file (default: "10Gi")
@@ -375,6 +383,8 @@ drivers:
       # -- Log verbosity level (0-5) (default: 0)
       verbosity: 0
       rotation:
+        # -- Enable log rotation (default: true)
+        enabled: true
         # -- Maximum number of log files to keep (default: 7)
         maxFiles: 7
         # -- Maximum size of each log file (default: "10Gi")

--- a/docs/helm-charts/drivers-chart.md
+++ b/docs/helm-charts/drivers-chart.md
@@ -96,6 +96,7 @@ The following table lists the configurable parameters of the ceph-csi-drivers ch
 | `drivers.cephfs.grpcTimeout` | gRPC timeout in seconds (default: 30) | `30` |
 | `drivers.cephfs.imageSet.name` | ConfigMap reference to the image set for the driver (default: "") | `""` |
 | `drivers.cephfs.kernelMountOptions` | Kernel mount options (default: {}) | `{}` |
+| `drivers.cephfs.log.rotation.enabled` | Enable log rotation (default: true) | `true` |
 | `drivers.cephfs.log.rotation.logHostPath` | Default log directory path (default: "") | `""` |
 | `drivers.cephfs.log.rotation.maxFiles` | Maximum number of log files to keep (default: 7) | `7` |
 | `drivers.cephfs.log.rotation.maxLogSize` | Maximum size of each log file (default: "10Gi") | `"10Gi"` |
@@ -131,6 +132,7 @@ The following table lists the configurable parameters of the ceph-csi-drivers ch
 | `drivers.nfs.grpcTimeout` | gRPC timeout in seconds (default: 30) | `30` |
 | `drivers.nfs.imageSet.name` | ConfigMap reference to the image set for the driver (default: "") | `""` |
 | `drivers.nfs.kernelMountOptions` | Kernel mount options (default: {}) | `{}` |
+| `drivers.nfs.log.rotation.enabled` | Enable log rotation (default: true) | `true` |
 | `drivers.nfs.log.rotation.logHostPath` | Default log directory path (default: "") | `""` |
 | `drivers.nfs.log.rotation.maxFiles` | Maximum number of log files to keep (default: 7) | `7` |
 | `drivers.nfs.log.rotation.maxLogSize` | Maximum size of each log file (default: "10Gi") | `"10Gi"` |
@@ -167,6 +169,7 @@ The following table lists the configurable parameters of the ceph-csi-drivers ch
 | `drivers.nvmeof.grpcTimeout` | gRPC timeout in seconds (default: 30) | `30` |
 | `drivers.nvmeof.imageSet.name` | ConfigMap reference to the image set for the driver (default: "") | `""` |
 | `drivers.nvmeof.kernelMountOptions` | Kernel mount options (default: {}) | `{}` |
+| `drivers.nvmeof.log.rotation.enabled` | Enable log rotation (default: true) | `true` |
 | `drivers.nvmeof.log.rotation.logHostPath` | Default log directory path (default: "") | `""` |
 | `drivers.nvmeof.log.rotation.maxFiles` | Maximum number of log files to keep (default: 7) | `7` |
 | `drivers.nvmeof.log.rotation.maxLogSize` | Maximum size of each log file (default: "10Gi") | `"10Gi"` |
@@ -202,6 +205,7 @@ The following table lists the configurable parameters of the ceph-csi-drivers ch
 | `drivers.rbd.grpcTimeout` | gRPC timeout in seconds (default: 30) | `30` |
 | `drivers.rbd.imageSet.name` | ConfigMap reference to the image set for the driver (default: "") | `""` |
 | `drivers.rbd.kernelMountOptions` | Kernel mount options (default: {}) | `{}` |
+| `drivers.rbd.log.rotation.enabled` | Enable log rotation (default: true) | `true` |
 | `drivers.rbd.log.rotation.logHostPath` | Default log directory path (default: "") | `""` |
 | `drivers.rbd.log.rotation.maxFiles` | Maximum number of log files to keep (default: 7) | `7` |
 | `drivers.rbd.log.rotation.maxLogSize` | Maximum size of each log file (default: "10Gi") | `"10Gi"` |
@@ -242,6 +246,7 @@ The following table lists the configurable parameters of the ceph-csi-drivers ch
 | `operatorConfig.driverSpecDefaults.grpcTimeout` | gRPC timeout in seconds (default: 30) | `30` |
 | `operatorConfig.driverSpecDefaults.imageSet.name` | ConfigMap reference to the image set for the driver (default: "") | `""` |
 | `operatorConfig.driverSpecDefaults.kernelMountOptions` | Kernel mount options (default: {}) | `{}` |
+| `operatorConfig.driverSpecDefaults.log.rotation.enabled` | Enable log rotation (default: true) | `true` |
 | `operatorConfig.driverSpecDefaults.log.rotation.logHostPath` | Default log directory path (default: "") | `""` |
 | `operatorConfig.driverSpecDefaults.log.rotation.maxFiles` | Maximum number of log files to keep (default: 7) | `7` |
 | `operatorConfig.driverSpecDefaults.log.rotation.maxLogSize` | Maximum size of each log file (default: "10Gi") | `"10Gi"` |


### PR DESCRIPTION
# Describe what this PR does #

add enabled flag so that we can disable log rotation when required in the ceph-csi-driver chart

## Related issues ##

Mention any github issues relevant to this PR. Adding below line
will help to auto close the issue once the PR is merged.

Fixes: https://github.com/ceph/ceph-csi-operator/issues/383

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#development-workflow)
* [x] [Pending release notes](https://github.com/ceph/ceph-csi-operator/blob/main/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [x] Documentation has been updated, if necessary.
* [x] Unit tests have been added, if necessary.
* [x] Integration tests have been added, if necessary.
