### PR TITLE
helm: guard deprecated enableMetadata against nil values

### DIFF
--- a/deploy/charts/ceph-csi-drivers/templates/driver.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/driver.yaml
@@ -31,7 +31,9 @@ spec:
   {{- if $driver.clusterName }}
   clusterName: {{ $driver.clusterName }}
   {{- end }}
+  {{- if ne $driver.enableMetadata nil }}
   enableMetadata: {{ $driver.enableMetadata }}
+  {{- end }}
   enableFencing: {{ $driver.enableFencing }}
   grpcTimeout: {{ $driver.grpcTimeout }}
   snapshotPolicy: {{ $driver.snapshotPolicy }}

--- a/deploy/charts/ceph-csi-drivers/templates/operatorConfig.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/operatorConfig.yaml
@@ -35,7 +35,9 @@ spec:
     {{- if $config.driverSpecDefaults.clusterName }}
     clusterName: {{ $config.driverSpecDefaults.clusterName }}
     {{- end }}
+    {{- if ne $config.driverSpecDefaults.enableMetadata nil }}
     enableMetadata: {{ $config.driverSpecDefaults.enableMetadata }}
+    {{- end }}
     enableFencing: {{ $config.driverSpecDefaults.enableFencing }}
     grpcTimeout: {{ $config.driverSpecDefaults.grpcTimeout }}
     snapshotPolicy: {{ $config.driverSpecDefaults.snapshotPolicy }}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi-operator! -->

# Describe what this PR does #

The enableMetadata default was removed from values.yaml when the field was deprecated, but the templates still referenced it unconditionally. This caused helm install/upgrade to render enableMetadata as null, which the CRD rejects as an invalid boolean value.

Wrap the field with a nil check so it is omitted when not set (new installs) but still rendered when explicitly provided (upgrades from older chart versions).

Fixes: #473

---
_FYI: Future release of ceph-csi will remove the flag completely_
https://github.com/ceph/ceph-csi/blob/38c69b5dbecf924dfa83c43eecc469e705f03601/cmd/cephcsi.go#L215-L222

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#development-workflow)
* [ ] [Pending release notes](https://github.com/ceph/ceph-csi-operator/blob/main/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.
