### PR TITLE
change maxLogSize units to base 10 (remove the 'i')

### DIFF
--- a/deploy/charts/ceph-csi-drivers/values.yaml
+++ b/deploy/charts/ceph-csi-drivers/values.yaml
@@ -45,7 +45,7 @@ operatorConfig:
         enabled: true
         # -- Maximum number of log files to keep (default: 7)
         maxFiles: 7
-        # -- Maximum size of each log file (default: "10Gi")
+        # -- Maximum size of each log file (default: "10G")
         maxLogSize: "10G"
         # -- Periodicity for log rotation (options: hourly, daily, weekly, monthly) (default: "daily")
         periodicity: "daily"
@@ -138,7 +138,7 @@ drivers:
         enabled: true
         # -- Maximum number of log files to keep (default: 7)
         maxFiles: 7
-        # -- Maximum size of each log file (default: "10Gi")
+        # -- Maximum size of each log file (default: "10G")
         maxLogSize: "10G"
         # -- Periodicity for log rotation (options: hourly, daily, weekly, monthly) (default: "daily")
         periodicity: "daily"
@@ -221,7 +221,7 @@ drivers:
         enabled: true
         # -- Maximum number of log files to keep (default: 7)
         maxFiles: 7
-        # -- Maximum size of each log file (default: "10Gi")
+        # -- Maximum size of each log file (default: "10G")
         maxLogSize: "10G"
         # -- Periodicity for log rotation (options: hourly, daily, weekly, monthly) (default: "daily")
         periodicity: "daily"
@@ -304,7 +304,7 @@ drivers:
         enabled: true
         # -- Maximum number of log files to keep (default: 7)
         maxFiles: 7
-        # -- Maximum size of each log file (default: "10Gi")
+        # -- Maximum size of each log file (default: "10G")
         maxLogSize: "10G"
         # -- Periodicity for log rotation (options: hourly, daily, weekly, monthly) (default: "daily")
         periodicity: "daily"
@@ -387,7 +387,7 @@ drivers:
         enabled: true
         # -- Maximum number of log files to keep (default: 7)
         maxFiles: 7
-        # -- Maximum size of each log file (default: "10Gi")
+        # -- Maximum size of each log file (default: "10G")
         maxLogSize: "10G"
         # -- Periodicity for log rotation (options: hourly, daily, weekly, monthly) (default: "daily")
         periodicity: "daily"

--- a/deploy/charts/ceph-csi-drivers/values.yaml
+++ b/deploy/charts/ceph-csi-drivers/values.yaml
@@ -46,7 +46,7 @@ operatorConfig:
         # -- Maximum number of log files to keep (default: 7)
         maxFiles: 7
         # -- Maximum size of each log file (default: "10Gi")
-        maxLogSize: "10Gi"
+        maxLogSize: "10G"
         # -- Periodicity for log rotation (options: hourly, daily, weekly, monthly) (default: "daily")
         periodicity: "daily"
         # -- Default log directory path (default: "")
@@ -139,7 +139,7 @@ drivers:
         # -- Maximum number of log files to keep (default: 7)
         maxFiles: 7
         # -- Maximum size of each log file (default: "10Gi")
-        maxLogSize: "10Gi"
+        maxLogSize: "10G"
         # -- Periodicity for log rotation (options: hourly, daily, weekly, monthly) (default: "daily")
         periodicity: "daily"
         # -- Default log directory path (default: "")
@@ -222,7 +222,7 @@ drivers:
         # -- Maximum number of log files to keep (default: 7)
         maxFiles: 7
         # -- Maximum size of each log file (default: "10Gi")
-        maxLogSize: "10Gi"
+        maxLogSize: "10G"
         # -- Periodicity for log rotation (options: hourly, daily, weekly, monthly) (default: "daily")
         periodicity: "daily"
         # -- Default log directory path (default: "")
@@ -305,7 +305,7 @@ drivers:
         # -- Maximum number of log files to keep (default: 7)
         maxFiles: 7
         # -- Maximum size of each log file (default: "10Gi")
-        maxLogSize: "10Gi"
+        maxLogSize: "10G"
         # -- Periodicity for log rotation (options: hourly, daily, weekly, monthly) (default: "daily")
         periodicity: "daily"
         # -- Default log directory path (default: "")
@@ -388,7 +388,7 @@ drivers:
         # -- Maximum number of log files to keep (default: 7)
         maxFiles: 7
         # -- Maximum size of each log file (default: "10Gi")
-        maxLogSize: "10Gi"
+        maxLogSize: "10G"
         # -- Periodicity for log rotation (options: hourly, daily, weekly, monthly) (default: "daily")
         periodicity: "daily"
         # -- Default log directory path (default: "")

--- a/docs/helm-charts/drivers-chart.md
+++ b/docs/helm-charts/drivers-chart.md
@@ -99,7 +99,7 @@ The following table lists the configurable parameters of the ceph-csi-drivers ch
 | `drivers.cephfs.log.rotation.enabled` | Enable log rotation (default: true) | `true` |
 | `drivers.cephfs.log.rotation.logHostPath` | Default log directory path (default: "") | `""` |
 | `drivers.cephfs.log.rotation.maxFiles` | Maximum number of log files to keep (default: 7) | `7` |
-| `drivers.cephfs.log.rotation.maxLogSize` | Maximum size of each log file (default: "10Gi") | `"10Gi"` |
+| `drivers.cephfs.log.rotation.maxLogSize` | Maximum size of each log file (default: "10G") | `"10G"` |
 | `drivers.cephfs.log.rotation.periodicity` | Periodicity for log rotation (options: hourly, daily, weekly, monthly) (default: "daily") | `"daily"` |
 | `drivers.cephfs.log.verbosity` | Log verbosity level (0-5) (default: 0) | `0` |
 | `drivers.cephfs.name` | CSI driver name for CephFS (default: "cephfs.csi.ceph.com") | `"cephfs.csi.ceph.com"` |
@@ -135,7 +135,7 @@ The following table lists the configurable parameters of the ceph-csi-drivers ch
 | `drivers.nfs.log.rotation.enabled` | Enable log rotation (default: true) | `true` |
 | `drivers.nfs.log.rotation.logHostPath` | Default log directory path (default: "") | `""` |
 | `drivers.nfs.log.rotation.maxFiles` | Maximum number of log files to keep (default: 7) | `7` |
-| `drivers.nfs.log.rotation.maxLogSize` | Maximum size of each log file (default: "10Gi") | `"10Gi"` |
+| `drivers.nfs.log.rotation.maxLogSize` | Maximum size of each log file (default: "10G") | `"10G"` |
 | `drivers.nfs.log.rotation.periodicity` | Periodicity for log rotation (options: hourly, daily, weekly, monthly) (default: "daily") | `"daily"` |
 | `drivers.nfs.log.verbosity` | Log verbosity level (0-5) (default: 0) | `0` |
 | `drivers.nfs.name` | CSI driver name for NFS (default: "nfs.csi.ceph.com") | `"nfs.csi.ceph.com"` |
@@ -172,7 +172,7 @@ The following table lists the configurable parameters of the ceph-csi-drivers ch
 | `drivers.nvmeof.log.rotation.enabled` | Enable log rotation (default: true) | `true` |
 | `drivers.nvmeof.log.rotation.logHostPath` | Default log directory path (default: "") | `""` |
 | `drivers.nvmeof.log.rotation.maxFiles` | Maximum number of log files to keep (default: 7) | `7` |
-| `drivers.nvmeof.log.rotation.maxLogSize` | Maximum size of each log file (default: "10Gi") | `"10Gi"` |
+| `drivers.nvmeof.log.rotation.maxLogSize` | Maximum size of each log file (default: "10G") | `"10G"` |
 | `drivers.nvmeof.log.rotation.periodicity` | Periodicity for log rotation (options: hourly, daily, weekly, monthly) (default: "daily") | `"daily"` |
 | `drivers.nvmeof.log.verbosity` | Log verbosity level (0-5) (default: 0) | `0` |
 | `drivers.nvmeof.name` | CSI driver name for NVMe-oF (default: "nvmeof.csi.ceph.com") | `"nvmeof.csi.ceph.com"` |
@@ -208,7 +208,7 @@ The following table lists the configurable parameters of the ceph-csi-drivers ch
 | `drivers.rbd.log.rotation.enabled` | Enable log rotation (default: true) | `true` |
 | `drivers.rbd.log.rotation.logHostPath` | Default log directory path (default: "") | `""` |
 | `drivers.rbd.log.rotation.maxFiles` | Maximum number of log files to keep (default: 7) | `7` |
-| `drivers.rbd.log.rotation.maxLogSize` | Maximum size of each log file (default: "10Gi") | `"10Gi"` |
+| `drivers.rbd.log.rotation.maxLogSize` | Maximum size of each log file (default: "10G") | `"10G"` |
 | `drivers.rbd.log.rotation.periodicity` | Periodicity for log rotation (options: hourly, daily, weekly, monthly) (default: "daily") | `"daily"` |
 | `drivers.rbd.log.verbosity` | Log verbosity level (0-5) (default: 0) | `0` |
 | `drivers.rbd.name` | CSI driver name for RBD (default: "rbd.csi.ceph.com") | `"rbd.csi.ceph.com"` |
@@ -249,7 +249,7 @@ The following table lists the configurable parameters of the ceph-csi-drivers ch
 | `operatorConfig.driverSpecDefaults.log.rotation.enabled` | Enable log rotation (default: true) | `true` |
 | `operatorConfig.driverSpecDefaults.log.rotation.logHostPath` | Default log directory path (default: "") | `""` |
 | `operatorConfig.driverSpecDefaults.log.rotation.maxFiles` | Maximum number of log files to keep (default: 7) | `7` |
-| `operatorConfig.driverSpecDefaults.log.rotation.maxLogSize` | Maximum size of each log file (default: "10Gi") | `"10Gi"` |
+| `operatorConfig.driverSpecDefaults.log.rotation.maxLogSize` | Maximum size of each log file (default: "10G") | `"10G"` |
 | `operatorConfig.driverSpecDefaults.log.rotation.periodicity` | Periodicity for log rotation (options: hourly, daily, weekly, monthly) (default: "daily") | `"daily"` |
 | `operatorConfig.driverSpecDefaults.log.verbosity` | Log verbosity level (0-5) (default: 0) | `0` |
 | `operatorConfig.driverSpecDefaults.nodePlugin.affinity` | Affinity settings for the pod (default: {}) | `{}` |


### PR DESCRIPTION
* when using base 2 (Gi) there are logging errors: found error in /csi-logs/*.log , skipping /logrotate-config/csi:8 unknown unit 'i'

<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi-operator! -->

# Describe what this PR does #

When using base 2 (Gi) there are logging errors from the log rotater:

```found error in /csi-logs/*.log , skipping /logrotate-config/csi:8 unknown unit 'i'```

This changes maxLogSize units to base 10 (remove the 'i') in the ceph-csi-drivers values.yaml file and updates the driver-chart.md file.

## Is there anything that requires special attention ##

Do you have any questions? No

Is the change backward compatible? No

Are there concerns around backward compatibility? No

Provide any external context for the change, if any.

The ```found error in /csi-logs/*.log , skipping /logrotate-config/csi:8 unknown unit 'i'``` error messages no longer appeared after changing these in my own values.yaml file.

## Related issues ##

Fixes: #491

## Future concerns ##

None.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#development-workflow)
* [x] [Pending release
  notes](https://github.com/ceph/ceph-csi-operator/blob/main/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [x] Documentation has been updated, if necessary.
* [x] Unit tests have been added, if necessary.
* [x] Integration tests have been added, if necessary.
