### PR TITLE
helm: add volumeattributesclasses RBAC to ctrlplugin ClusterRoles

### DIFF
--- a/deploy/charts/ceph-csi-drivers/templates/cephfs-ctrlplugin-cr-rbac.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/cephfs-ctrlplugin-cr-rbac.yaml
@@ -212,4 +212,12 @@ rules:
   - tokenreviews
   verbs:
   - create
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattributesclasses
+  verbs:
+  - get
+  - list
+  - watch
 {{- end }}

--- a/deploy/charts/ceph-csi-drivers/templates/nfs-ctrlplugin-cr-rbac.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/nfs-ctrlplugin-cr-rbac.yaml
@@ -134,4 +134,12 @@ rules:
   - volumeattachments/status
   verbs:
   - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattributesclasses
+  verbs:
+  - get
+  - list
+  - watch
 {{- end }}

--- a/deploy/charts/ceph-csi-drivers/templates/nvmeof-ctrlplugin-cr-rbac.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/nvmeof-ctrlplugin-cr-rbac.yaml
@@ -227,4 +227,12 @@ rules:
   verbs:
   - get
   - list
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattributesclasses
+  verbs:
+  - get
+  - list
+  - watch
 {{- end }}

--- a/deploy/charts/ceph-csi-drivers/templates/rbd-ctrlplugin-cr-rbac.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/rbd-ctrlplugin-cr-rbac.yaml
@@ -227,4 +227,12 @@ rules:
   verbs:
   - get
   - list
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattributesclasses
+  verbs:
+  - get
+  - list
+  - watch
 {{- end }}


### PR DESCRIPTION
## Problem

PR #401 added `volumeattributesclasses` to `config/csi-rbac/` manifests but missed the helm chart templates under `deploy/charts/ceph-csi-drivers/templates/`. As a result, the deployed ClusterRoles are missing the permission and the `csi-resizer` sidecar (v2.0.0+) logs errors repeatedly:

```
E Failed to watch err="failed to list *v1.VolumeAttributesClass: volumeattributesclasses.storage.k8s.io is forbidden: \
  User \"system:serviceaccount:rook-ceph:rook-ceph-rbd-csi-ceph-com-ctrlplugin-sa\" cannot list resource \
  \"volumeattributesclasses\" in API group \"storage.k8s.io\" at the cluster scope"
```

Tracked in #495.

## Fix

Add the missing `storage.k8s.io/volumeattributesclasses` `get/list/watch` rule to the `rbd`, `cephfs`, and `nfs` ctrlplugin ClusterRole helm templates, matching the existing entries in `config/csi-rbac/`.

## Testing

Verified the generated ClusterRole includes `volumeattributesclasses` and errors stop after applying the fix.