### PR TITLE
fix(helm): controllerPlugin and nodePlugin container resources

### DIFF
--- a/deploy/charts/ceph-csi-drivers/templates/driver.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/driver.yaml
@@ -70,11 +70,11 @@ spec:
     {{- end }}
     {{- if $driver.nodePlugin.resources }}
     resources:
-      registrar: {{ $driver.nodePlugin.resources.registrar | toYaml | nindent 8 }}
-      liveness: {{ $driver.nodePlugin.resources.liveness | toYaml | nindent 8 }}
-      addons: {{ $driver.nodePlugin.resources.addons | toYaml | nindent 8 }}
-      logRotator: {{ $driver.nodePlugin.resources.logRotator | toYaml | nindent 8 }}
-      plugin: {{ $driver.nodePlugin.resources.plugin | toYaml | nindent 8 }}
+      registrar: {{ $driver.nodePlugin.resources.registrar | default dict | toYaml | nindent 8 }}
+      liveness: {{ $driver.nodePlugin.resources.liveness | default dict | toYaml | nindent 8 }}
+      addons: {{ $driver.nodePlugin.resources.addons | default dict | toYaml | nindent 8 }}
+      logRotator: {{ $driver.nodePlugin.resources.logRotator | default dict | toYaml | nindent 8 }}
+      plugin: {{ $driver.nodePlugin.resources.plugin | default dict | toYaml | nindent 8 }}
     {{- end }}
     {{- if $driver.nodePlugin.kubeletDirPath }}
     kubeletDirPath: {{ $driver.nodePlugin.kubeletDirPath }}
@@ -125,15 +125,15 @@ spec:
     replicas: {{ $driver.controllerPlugin.replicas | default 2 }}
     {{- if $driver.controllerPlugin.resources }}
     resources:
-      attacher: {{ $driver.controllerPlugin.resources.attacher | toYaml | nindent 8 }}
-      snapshotter: {{ $driver.controllerPlugin.resources.snapshotter | toYaml | nindent 8 }}
-      resizer: {{ $driver.controllerPlugin.resources.resizer | toYaml | nindent 8 }}
-      provisioner: {{ $driver.controllerPlugin.resources.provisioner | toYaml | nindent 8 }}
-      omapGenerator: {{ $driver.controllerPlugin.resources.omapGenerator | toYaml | nindent 8 }}
-      liveness: {{ $driver.controllerPlugin.resources.liveness | toYaml | nindent 8 }}
-      addons: {{ $driver.controllerPlugin.resources.addons | toYaml | nindent 8 }}
-      logRotator: {{ $driver.controllerPlugin.resources.logRotator | toYaml | nindent 8 }}
-      plugin: {{ $driver.controllerPlugin.resources.plugin | toYaml | nindent 8 }}
+      attacher: {{ $driver.controllerPlugin.resources.attacher | default dict | toYaml | nindent 8 }}
+      snapshotter: {{ $driver.controllerPlugin.resources.snapshotter | default dict | toYaml | nindent 8 }}
+      resizer: {{ $driver.controllerPlugin.resources.resizer | default dict | toYaml | nindent 8 }}
+      provisioner: {{ $driver.controllerPlugin.resources.provisioner | default dict | toYaml | nindent 8 }}
+      omapGenerator: {{ $driver.controllerPlugin.resources.omapGenerator | default dict | toYaml | nindent 8 }}
+      liveness: {{ $driver.controllerPlugin.resources.liveness | default dict | toYaml | nindent 8 }}
+      addons: {{ $driver.controllerPlugin.resources.addons | default dict | toYaml | nindent 8 }}
+      logRotator: {{ $driver.controllerPlugin.resources.logRotator | default dict | toYaml | nindent 8 }}
+      plugin: {{ $driver.controllerPlugin.resources.plugin | default dict | toYaml | nindent 8 }}
     {{- end }}
     privileged: {{ $driver.controllerPlugin.privileged | default false }}
     {{- if $driver.controllerPlugin.priorityClassName }}

--- a/deploy/charts/ceph-csi-drivers/templates/operatorConfig.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/operatorConfig.yaml
@@ -73,11 +73,11 @@ spec:
       {{- end }}
       {{- if $config.driverSpecDefaults.nodePlugin.resources }}
       resources:
-        registrar: {{ $config.driverSpecDefaults.nodePlugin.resources.registrar | toYaml | nindent 4 }}
-        liveness: {{ $config.driverSpecDefaults.nodePlugin.resources.liveness | toYaml | nindent 4 }}
-        addons: {{ $config.driverSpecDefaults.nodePlugin.resources.addons | toYaml | nindent 4 }}
-        logRotator: {{ $config.driverSpecDefaults.nodePlugin.resources.logRotator | toYaml | nindent 4 }}
-        plugin: {{ $config.driverSpecDefaults.nodePlugin.resources.plugin | toYaml | nindent 4 }}
+        registrar: {{ $config.driverSpecDefaults.nodePlugin.resources.registrar | toYaml | nindent 10 }}
+        liveness: {{ $config.driverSpecDefaults.nodePlugin.resources.liveness | toYaml | nindent 10 }}
+        addons: {{ $config.driverSpecDefaults.nodePlugin.resources.addons | toYaml | nindent 10 }}
+        logRotator: {{ $config.driverSpecDefaults.nodePlugin.resources.logRotator | toYaml | nindent 10 }}
+        plugin: {{ $config.driverSpecDefaults.nodePlugin.resources.plugin | toYaml | nindent 10 }}
       {{- end }}
       {{- if $config.driverSpecDefaults.nodePlugin.kubeletDirPath }}
       kubeletDirPath: {{ $config.driverSpecDefaults.nodePlugin.kubeletDirPath }}
@@ -127,15 +127,15 @@ spec:
       replicas: {{ $config.driverSpecDefaults.controllerPlugin.replicas | default 2 }}
       {{- if $config.driverSpecDefaults.controllerPlugin.resources }}
       resources:
-        attacher: {{ $config.driverSpecDefaults.controllerPlugin.resources.attacher | toYaml | nindent 8 }}
-        snapshotter: {{ $config.driverSpecDefaults.controllerPlugin.resources.snapshotter | toYaml | nindent 8 }}
-        resizer: {{ $config.driverSpecDefaults.controllerPlugin.resources.resizer | toYaml | nindent 8 }}
-        provisioner: {{ $config.driverSpecDefaults.controllerPlugin.resources.provisioner | toYaml | nindent 8 }}
-        omapGenerator: {{ $config.driverSpecDefaults.controllerPlugin.resources.omapGenerator | toYaml | nindent 8 }}
-        liveness: {{ $config.driverSpecDefaults.controllerPlugin.resources.liveness | toYaml | nindent 8 }}
-        addons: {{ $config.driverSpecDefaults.controllerPlugin.resources.addons | toYaml | nindent 8 }}
-        logRotator: {{ $config.driverSpecDefaults.controllerPlugin.resources.logRotator | toYaml | nindent 8 }}
-        plugin: {{ $config.driverSpecDefaults.controllerPlugin.resources.plugin | toYaml | nindent 8 }}
+        attacher: {{ $config.driverSpecDefaults.controllerPlugin.resources.attacher | toYaml | nindent 10 }}
+        snapshotter: {{ $config.driverSpecDefaults.controllerPlugin.resources.snapshotter | toYaml | nindent 10 }}
+        resizer: {{ $config.driverSpecDefaults.controllerPlugin.resources.resizer | toYaml | nindent 10 }}
+        provisioner: {{ $config.driverSpecDefaults.controllerPlugin.resources.provisioner | toYaml | nindent 10 }}
+        omapGenerator: {{ $config.driverSpecDefaults.controllerPlugin.resources.omapGenerator | toYaml | nindent 10 }}
+        liveness: {{ $config.driverSpecDefaults.controllerPlugin.resources.liveness | toYaml | nindent 10 }}
+        addons: {{ $config.driverSpecDefaults.controllerPlugin.resources.addons | toYaml | nindent 10 }}
+        logRotator: {{ $config.driverSpecDefaults.controllerPlugin.resources.logRotator | toYaml | nindent 10 }}
+        plugin: {{ $config.driverSpecDefaults.controllerPlugin.resources.plugin | toYaml | nindent 10 }}
       {{- end }}
       privileged: {{ $config.driverSpecDefaults.controllerPlugin.privileged | default false }}
       {{- if $config.driverSpecDefaults.controllerPlugin.priorityClassName }}

--- a/deploy/charts/ceph-csi-drivers/templates/operatorConfig.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/operatorConfig.yaml
@@ -73,11 +73,11 @@ spec:
       {{- end }}
       {{- if $config.driverSpecDefaults.nodePlugin.resources }}
       resources:
-        registrar: {{ $config.driverSpecDefaults.nodePlugin.resources.registrar | toYaml | nindent 10 }}
-        liveness: {{ $config.driverSpecDefaults.nodePlugin.resources.liveness | toYaml | nindent 10 }}
-        addons: {{ $config.driverSpecDefaults.nodePlugin.resources.addons | toYaml | nindent 10 }}
-        logRotator: {{ $config.driverSpecDefaults.nodePlugin.resources.logRotator | toYaml | nindent 10 }}
-        plugin: {{ $config.driverSpecDefaults.nodePlugin.resources.plugin | toYaml | nindent 10 }}
+        registrar: {{ $config.driverSpecDefaults.nodePlugin.resources.registrar | default dict | toYaml | nindent 10 }}
+        liveness: {{ $config.driverSpecDefaults.nodePlugin.resources.liveness | default dict | toYaml | nindent 10 }}
+        addons: {{ $config.driverSpecDefaults.nodePlugin.resources.addons | default dict | toYaml | nindent 10 }}
+        logRotator: {{ $config.driverSpecDefaults.nodePlugin.resources.logRotator | default dict | toYaml | nindent 10 }}
+        plugin: {{ $config.driverSpecDefaults.nodePlugin.resources.plugin | default dict | toYaml | nindent 10 }}
       {{- end }}
       {{- if $config.driverSpecDefaults.nodePlugin.kubeletDirPath }}
       kubeletDirPath: {{ $config.driverSpecDefaults.nodePlugin.kubeletDirPath }}
@@ -127,15 +127,15 @@ spec:
       replicas: {{ $config.driverSpecDefaults.controllerPlugin.replicas | default 2 }}
       {{- if $config.driverSpecDefaults.controllerPlugin.resources }}
       resources:
-        attacher: {{ $config.driverSpecDefaults.controllerPlugin.resources.attacher | toYaml | nindent 10 }}
-        snapshotter: {{ $config.driverSpecDefaults.controllerPlugin.resources.snapshotter | toYaml | nindent 10 }}
-        resizer: {{ $config.driverSpecDefaults.controllerPlugin.resources.resizer | toYaml | nindent 10 }}
-        provisioner: {{ $config.driverSpecDefaults.controllerPlugin.resources.provisioner | toYaml | nindent 10 }}
-        omapGenerator: {{ $config.driverSpecDefaults.controllerPlugin.resources.omapGenerator | toYaml | nindent 10 }}
-        liveness: {{ $config.driverSpecDefaults.controllerPlugin.resources.liveness | toYaml | nindent 10 }}
-        addons: {{ $config.driverSpecDefaults.controllerPlugin.resources.addons | toYaml | nindent 10 }}
-        logRotator: {{ $config.driverSpecDefaults.controllerPlugin.resources.logRotator | toYaml | nindent 10 }}
-        plugin: {{ $config.driverSpecDefaults.controllerPlugin.resources.plugin | toYaml | nindent 10 }}
+        attacher: {{ $config.driverSpecDefaults.controllerPlugin.resources.attacher | default dict | toYaml | nindent 10 }}
+        snapshotter: {{ $config.driverSpecDefaults.controllerPlugin.resources.snapshotter | default dict | toYaml | nindent 10 }}
+        resizer: {{ $config.driverSpecDefaults.controllerPlugin.resources.resizer | default dict | toYaml | nindent 10 }}
+        provisioner: {{ $config.driverSpecDefaults.controllerPlugin.resources.provisioner | default dict | toYaml | nindent 10 }}
+        omapGenerator: {{ $config.driverSpecDefaults.controllerPlugin.resources.omapGenerator | default dict | toYaml | nindent 10 }}
+        liveness: {{ $config.driverSpecDefaults.controllerPlugin.resources.liveness | default dict | toYaml | nindent 10 }}
+        addons: {{ $config.driverSpecDefaults.controllerPlugin.resources.addons | default dict | toYaml | nindent 10 }}
+        logRotator: {{ $config.driverSpecDefaults.controllerPlugin.resources.logRotator | default dict | toYaml | nindent 10 }}
+        plugin: {{ $config.driverSpecDefaults.controllerPlugin.resources.plugin | default dict | toYaml | nindent 10 }}
       {{- end }}
       privileged: {{ $config.driverSpecDefaults.controllerPlugin.privileged | default false }}
       {{- if $config.driverSpecDefaults.controllerPlugin.priorityClassName }}


### PR DESCRIPTION
# Describe what this PR does #

Fix the indent to generate a valid operatorConfig yaml file

Add a default value for container resources to be able to define only a subset of them

## Related issues ##

Fixes: #490 and #497 
