### PR TITLE
rbac: add volumeattributesclasses rules to nvmeof controller plugin

### DIFF
--- a/config/csi-rbac/nvmeof_ctrlplugin_cluster_role.yaml
+++ b/config/csi-rbac/nvmeof_ctrlplugin_cluster_role.yaml
@@ -48,3 +48,6 @@ rules:
   - apiGroups: ["authorization.k8s.io"]
     resources: ["subjectaccessreviews"]
     verbs: ["create"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattributesclasses"]
+    verbs: ["get", "list", "watch"]

--- a/deploy/all-in-one/install-openshift.yaml
+++ b/deploy/all-in-one/install-openshift.yaml
@@ -16120,6 +16120,14 @@ rules:
   - subjectaccessreviews
   verbs:
   - create
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattributesclasses
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/deploy/all-in-one/install.yaml
+++ b/deploy/all-in-one/install.yaml
@@ -16106,6 +16106,14 @@ rules:
   - subjectaccessreviews
   verbs:
   - create
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattributesclasses
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/deploy/multifile/csi-rbac.yaml
+++ b/deploy/multifile/csi-rbac.yaml
@@ -853,6 +853,14 @@ rules:
   - subjectaccessreviews
   verbs:
   - create
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattributesclasses
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
Add storage.k8s.io/volumeattributesclasses resource permissions
(get, list, watch) to the NVMe-oF controller plugin ClusterRole,
matching the configuration in the CephFS controller plugin.