### PR TITLE
fix(helm): only render CephConnection readAffinity when crushLocationLabels is set

### DIFF
--- a/deploy/charts/ceph-csi-drivers/templates/cephConnection.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/cephConnection.yaml
@@ -12,10 +12,12 @@ spec:
   - {{ . }}
   {{- end }}
   rbdMirrorDaemonCount: {{ $cephConnection.rbdMirrorDaemonCount }}
+  {{- with $cephConnection.crushLocationLabels }}
   readAffinity:
     crushLocationLabels:
-    {{- range $cephConnection.crushLocationLabels }}
+    {{- range . }}
     - {{ . }}
     {{- end }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/deploy/charts/ceph-csi-drivers/values.yaml
+++ b/deploy/charts/ceph-csi-drivers/values.yaml
@@ -6,8 +6,9 @@ cephConnections:
     monitors: {}
     # -- Number of RBD mirror daemons (default: 1)
     rbdMirrorDaemonCount: 1
-    # -- Labels to be used for CRUSH location selection (default: {})
-    crushLocationLabels: {}
+    # -- Labels to be used for CRUSH location selection (default: [])
+    # Leave empty to disable read affinity. When set, it must be a non-empty list of node label keys, e.g. ["topology.kubernetes.io/zone"].
+    crushLocationLabels: []
 # Configuration for Client Profiles
 clientProfiles:
   - # -- Name of the client profile (default: "")

--- a/docs/helm-charts/drivers-chart.md
+++ b/docs/helm-charts/drivers-chart.md
@@ -65,7 +65,7 @@ The following table lists the configurable parameters of the ceph-csi-drivers ch
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `cephConnections[0].crushLocationLabels` | Labels to be used for CRUSH location selection (default: {}) | `{}` |
+| `cephConnections[0].crushLocationLabels` | Labels to be used for CRUSH location selection (default: []) Leave empty to disable read affinity. When set, it must be a non-empty list of node label keys, e.g. ["topology.kubernetes.io/zone"]. | `[]` |
 | `cephConnections[0].monitors` | Ceph monitors (key-value pairs, typically IP addresses of the Ceph monitors) (default: {}) | `{}` |
 | `cephConnections[0].name` | Name for the Ceph connection (default: "") | `""` |
 | `cephConnections[0].rbdMirrorDaemonCount` | Number of RBD mirror daemons (default: 1) | `1` |


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi-operator! -->

# Describe what this PR does #

The `cephconnection.yaml` template in the `ceph-csi-drivers` chart always
renders the `spec.readAffinity.crushLocationLabels` key, regardless of whether
any CRUSH location labels are configured:

```yaml
  readAffinity:
    crushLocationLabels:
    {{- range $cephConnection.crushLocationLabels }}
    - {{ . }}
    {{- end }}
```

When `crushLocationLabels` is empty or unset (which is the chart default), the
`range` produces nothing and the rendered output becomes:

```yaml
  readAffinity:
    crushLocationLabels:
```

YAML parses that valueless key as `null`. The `CephConnection` CRD defines
`crushLocationLabels` as a required, non-empty array of strings inside the
otherwise-optional `readAffinity` block (`ReadAffinitySpec.CrushLocationLabels`
is `Optional`-on-`readAffinity` but `Required` + `MinItems=1` once present), so
the `null` value fails validation and the resource is rejected:
```
CephConnection.csi.ceph.io "ceph-cluster" is invalid:
spec.readAffinity.crushLocationLabels: Invalid value: "null":
spec.readAffinity.crushLocationLabels in body must be of type array: "null"
```

This makes it impossible to deploy a `CephConnection` without enabling read
affinity, even though both `readAffinity` and the field are meant to be
optional.

This PR wraps the whole `readAffinity` block in a `with`, so it is only rendered
when at least one CRUSH location label is provided:

```yaml
  rbdMirrorDaemonCount: {{ $cephConnection.rbdMirrorDaemonCount }}
  {{- with $cephConnection.crushLocationLabels }}
  readAffinity:
    crushLocationLabels:
    {{- range . }}
    - {{ . }}
    {{- end }}
  {{- end }}
```

With this change:
- no labels configured : the `readAffinity` block is omitted entirely and the
  CRD accepts the resource (field is optional);
- labels configured : output is unchanged from before.

## Is there anything that requires special attention ##

* The change is backward compatible. Users who set `crushLocationLabels` get
  exactly the same rendered output as today. Users who left it empty previously
  produced an invalid `CephConnection`; they now get a valid one with read
  affinity disabled, which matches the documented default (`{}`).
* No values-schema change is required; `cephConnections[].crushLocationLabels`
  keeps its current default.

## Related issues ##

Fixes: #508

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi-operator/blob/main/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [x] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.
