### PR TITLE
controller: set replicas if not set

### DIFF
--- a/api/v1/driver_types.go
+++ b/api/v1/driver_types.go
@@ -229,9 +229,12 @@ type ControllerPluginSpec struct {
 	//+kubebuilder:validation:Optional
 	DeploymentStrategy *appsv1.DeploymentStrategy `json:"deploymentStrategy,omitempty"`
 
-	// Set replicas for controller plugin's deployment. Defaults to 2
+	// Set replicas for controller plugin's deployment. Defaults to 2.
+	// On single-node clusters, the operator automatically caps the replica
+	// count to the number of available nodes when this field is not set.
 	//+kubebuilder:validation:Optional
 	//+kubebuilder:validation:Minimum:=1
+	//+kubebuilder:default:=2
 	Replicas *int32 `json:"replicas,omitempty"`
 
 	// Resource requirements for controller plugin's containers

--- a/config/crd/bases/csi.ceph.io_drivers.yaml
+++ b/config/crd/bases/csi.ceph.io_drivers.yaml
@@ -1076,8 +1076,11 @@ spec:
                       For example, OpenShift with SELinux restrictions requires the pod to be privileged to write to hostPath.
                     type: boolean
                   replicas:
-                    description: Set replicas for controller plugin's deployment.
-                      Defaults to 2
+                    default: 2
+                    description: |-
+                      Set replicas for controller plugin's deployment. Defaults to 2.
+                      On single-node clusters, the operator automatically caps the replica
+                      count to the number of available nodes when this field is not set.
                     format: int32
                     minimum: 1
                     type: integer

--- a/config/crd/bases/csi.ceph.io_operatorconfigs.yaml
+++ b/config/crd/bases/csi.ceph.io_operatorconfigs.yaml
@@ -1085,8 +1085,11 @@ spec:
                           For example, OpenShift with SELinux restrictions requires the pod to be privileged to write to hostPath.
                         type: boolean
                       replicas:
-                        description: Set replicas for controller plugin's deployment.
-                          Defaults to 2
+                        default: 2
+                        description: |-
+                          Set replicas for controller plugin's deployment. Defaults to 2.
+                          On single-node clusters, the operator automatically caps the replica
+                          count to the number of available nodes when this field is not set.
                         format: int32
                         minimum: 1
                         type: integer

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -18,6 +18,13 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - apps
   resources:
   - daemonsets

--- a/deploy/all-in-one/install-openshift.yaml
+++ b/deploy/all-in-one/install-openshift.yaml
@@ -1459,8 +1459,11 @@ spec:
                       For example, OpenShift with SELinux restrictions requires the pod to be privileged to write to hostPath.
                     type: boolean
                   replicas:
-                    description: Set replicas for controller plugin's deployment.
-                      Defaults to 2
+                    default: 2
+                    description: |-
+                      Set replicas for controller plugin's deployment. Defaults to 2.
+                      On single-node clusters, the operator automatically caps the replica
+                      count to the number of available nodes when this field is not set.
                     format: int32
                     minimum: 1
                     type: integer
@@ -8669,8 +8672,11 @@ spec:
                           For example, OpenShift with SELinux restrictions requires the pod to be privileged to write to hostPath.
                         type: boolean
                       replicas:
-                        description: Set replicas for controller plugin's deployment.
-                          Defaults to 2
+                        default: 2
+                        description: |-
+                          Set replicas for controller plugin's deployment. Defaults to 2.
+                          On single-node clusters, the operator automatically caps the replica
+                          count to the number of available nodes when this field is not set.
                         format: int32
                         minimum: 1
                         type: integer
@@ -15725,6 +15731,13 @@ rules:
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
   - watch
 - apiGroups:
   - apps

--- a/deploy/all-in-one/install.yaml
+++ b/deploy/all-in-one/install.yaml
@@ -1459,8 +1459,11 @@ spec:
                       For example, OpenShift with SELinux restrictions requires the pod to be privileged to write to hostPath.
                     type: boolean
                   replicas:
-                    description: Set replicas for controller plugin's deployment.
-                      Defaults to 2
+                    default: 2
+                    description: |-
+                      Set replicas for controller plugin's deployment. Defaults to 2.
+                      On single-node clusters, the operator automatically caps the replica
+                      count to the number of available nodes when this field is not set.
                     format: int32
                     minimum: 1
                     type: integer
@@ -8669,8 +8672,11 @@ spec:
                           For example, OpenShift with SELinux restrictions requires the pod to be privileged to write to hostPath.
                         type: boolean
                       replicas:
-                        description: Set replicas for controller plugin's deployment.
-                          Defaults to 2
+                        default: 2
+                        description: |-
+                          Set replicas for controller plugin's deployment. Defaults to 2.
+                          On single-node clusters, the operator automatically caps the replica
+                          count to the number of available nodes when this field is not set.
                         format: int32
                         minimum: 1
                         type: integer
@@ -15711,6 +15717,13 @@ rules:
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
   - watch
 - apiGroups:
   - apps

--- a/deploy/charts/ceph-csi-operator/templates/driver-crd.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/driver-crd.yaml
@@ -1076,8 +1076,11 @@ spec:
                       For example, OpenShift with SELinux restrictions requires the pod to be privileged to write to hostPath.
                     type: boolean
                   replicas:
-                    description: Set replicas for controller plugin's deployment. Defaults
-                      to 2
+                    default: 2
+                    description: |-
+                      Set replicas for controller plugin's deployment. Defaults to 2.
+                      On single-node clusters, the operator automatically caps the replica
+                      count to the number of available nodes when this field is not set.
                     format: int32
                     minimum: 1
                     type: integer

--- a/deploy/charts/ceph-csi-operator/templates/manager-rbac.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/manager-rbac.yaml
@@ -19,6 +19,13 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - apps
   resources:
   - daemonsets

--- a/deploy/charts/ceph-csi-operator/templates/operatorconfig-crd.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/operatorconfig-crd.yaml
@@ -1082,8 +1082,11 @@ spec:
                           For example, OpenShift with SELinux restrictions requires the pod to be privileged to write to hostPath.
                         type: boolean
                       replicas:
-                        description: Set replicas for controller plugin's deployment.
-                          Defaults to 2
+                        default: 2
+                        description: |-
+                          Set replicas for controller plugin's deployment. Defaults to 2.
+                          On single-node clusters, the operator automatically caps the replica
+                          count to the number of available nodes when this field is not set.
                         format: int32
                         minimum: 1
                         type: integer

--- a/deploy/multifile/crd.yaml
+++ b/deploy/multifile/crd.yaml
@@ -1450,8 +1450,11 @@ spec:
                       For example, OpenShift with SELinux restrictions requires the pod to be privileged to write to hostPath.
                     type: boolean
                   replicas:
-                    description: Set replicas for controller plugin's deployment.
-                      Defaults to 2
+                    default: 2
+                    description: |-
+                      Set replicas for controller plugin's deployment. Defaults to 2.
+                      On single-node clusters, the operator automatically caps the replica
+                      count to the number of available nodes when this field is not set.
                     format: int32
                     minimum: 1
                     type: integer
@@ -8660,8 +8663,11 @@ spec:
                           For example, OpenShift with SELinux restrictions requires the pod to be privileged to write to hostPath.
                         type: boolean
                       replicas:
-                        description: Set replicas for controller plugin's deployment.
-                          Defaults to 2
+                        default: 2
+                        description: |-
+                          Set replicas for controller plugin's deployment. Defaults to 2.
+                          On single-node clusters, the operator automatically caps the replica
+                          count to the number of available nodes when this field is not set.
                         format: int32
                         minimum: 1
                         type: integer

--- a/deploy/multifile/operator.yaml
+++ b/deploy/multifile/operator.yaml
@@ -276,6 +276,13 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - apps
   resources:
   - daemonsets

--- a/internal/controller/defaults.go
+++ b/internal/controller/defaults.go
@@ -39,10 +39,11 @@ var imageDefaults = map[string]string{
 }
 
 const (
-	defaultGRrpcTimeout      = 150
-	defaultKubeletDirPath    = "/var/lib/kubelet"
-	defaultLogHostPath       = "/var/lib/cephcsi"
-	defaultLogRotateMaxFiles = 7
+	defaultGRrpcTimeout                   = 150
+	defaultKubeletDirPath                 = "/var/lib/kubelet"
+	defaultLogHostPath                    = "/var/lib/cephcsi"
+	defaultLogRotateMaxFiles              = 7
+	defaultControllerPluginReplicas int32 = 2
 )
 
 var defaultLeaderElection = csiv1.LeaderElectionSpec{

--- a/internal/controller/driver_controller.go
+++ b/internal/controller/driver_controller.go
@@ -60,6 +60,7 @@ import (
 //+kubebuilder:rbac:groups=storage.k8s.io,resources=csidrivers,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="",resources=nodes,verbs=list;watch
 //+kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
 
 type DriverType string
@@ -566,8 +567,10 @@ func (r *driverReconcile) reconcileControllerPluginDeployment() error {
 		nodePluginSpec := cmp.Or(r.driver.Spec.NodePlugin, &csiv1.NodePluginSpec{})
 		topology := r.isRbdDriver() && nodePluginSpec.Topology != nil
 
+		replicas := r.getControllerPluginReplicas(log, pluginSpec.Replicas)
+
 		deploy.Spec = appsv1.DeploymentSpec{
-			Replicas: pluginSpec.Replicas,
+			Replicas: replicas,
 			Selector: &appSelector,
 			Strategy: ptr.Deref(pluginSpec.DeploymentStrategy, defaultDeploymentStrategy),
 			Template: corev1.PodTemplateSpec{
@@ -1665,6 +1668,31 @@ func (r *driverReconcile) generateServiceName(suffix string) string {
 	re := regexp.MustCompile(`[^a-z0-9-]`)
 	// Replace all special characters with a hyphen
 	return re.ReplaceAllString(name, "-")
+}
+
+func (r *driverReconcile) getControllerPluginReplicas(
+	log logr.Logger,
+	specReplicas *int32,
+) *int32 {
+	if specReplicas != nil {
+		return specReplicas
+	}
+
+	var replicas int32 = defaultControllerPluginReplicas
+	nodeList := &corev1.NodeList{}
+	if err := r.List(r.ctx, nodeList); err != nil {
+		log.Error(err, "Failed to list nodes for replica calculation")
+		return &replicas
+	}
+
+	nodeCount := len(nodeList.Items)
+	if nodeCount > 0 && nodeCount < int(replicas) {
+		replicas = 1
+		log.Info("Capping controller replicas to node count",
+			"default", defaultControllerPluginReplicas, "nodeCount", nodeCount)
+	}
+
+	return &replicas
 }
 
 func getControllerPluginPodAffinity(

--- a/internal/controller/driver_controller_test.go
+++ b/internal/controller/driver_controller_test.go
@@ -18,11 +18,15 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -79,6 +83,87 @@ var _ = Describe("Driver Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
 			// Example: If you expect a certain status condition after reconciliation, verify it here.
+		})
+	})
+
+	Context("getControllerPluginReplicas", func() {
+		var (
+			reconciler driverReconcile
+			log        = zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true))
+		)
+
+		BeforeEach(func() {
+			reconciler = driverReconcile{
+				DriverReconciler: DriverReconciler{
+					Client: k8sClient,
+					Scheme: k8sClient.Scheme(),
+				},
+				ctx: context.Background(),
+				log: log,
+			}
+		})
+
+		It("should return specReplicas when explicitly set", func() {
+			specReplicas := ptr.To(int32(5))
+			result := reconciler.getControllerPluginReplicas(log, specReplicas)
+			Expect(result).To(Equal(specReplicas))
+		})
+
+		It("should return default replicas when no nodes exist", func() {
+			result := reconciler.getControllerPluginReplicas(log, nil)
+			Expect(*result).To(Equal(defaultControllerPluginReplicas))
+		})
+
+		It("should cap replicas to 1 on a single-node cluster", func() {
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "single-node",
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), node)).To(Succeed())
+			defer func() {
+				Expect(k8sClient.Delete(context.Background(), node)).To(Succeed())
+			}()
+
+			result := reconciler.getControllerPluginReplicas(log, nil)
+			Expect(*result).To(Equal(int32(1)))
+		})
+
+		It("should return default replicas when node count meets default", func() {
+			nodes := make([]*corev1.Node, defaultControllerPluginReplicas)
+			for i := range nodes {
+				nodes[i] = &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: fmt.Sprintf("node-%d", i),
+					},
+				}
+				Expect(k8sClient.Create(context.Background(), nodes[i])).To(Succeed())
+			}
+			defer func() {
+				for _, n := range nodes {
+					Expect(k8sClient.Delete(context.Background(), n)).To(Succeed())
+				}
+			}()
+
+			result := reconciler.getControllerPluginReplicas(log, nil)
+			Expect(*result).To(Equal(defaultControllerPluginReplicas))
+		})
+
+		It("should not cap when specReplicas is set even on single-node cluster", func() {
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "only-node",
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), node)).To(Succeed())
+			defer func() {
+				Expect(k8sClient.Delete(context.Background(), node)).To(Succeed())
+			}()
+
+			specReplicas := ptr.To(int32(3))
+			result := reconciler.getControllerPluginReplicas(log, specReplicas)
+			Expect(result).To(Equal(specReplicas))
+			Expect(*result).To(Equal(int32(3)))
 		})
 	})
 })

--- a/vendor/github.com/ceph/ceph-csi-operator/api/v1/driver_types.go
+++ b/vendor/github.com/ceph/ceph-csi-operator/api/v1/driver_types.go
@@ -229,9 +229,12 @@ type ControllerPluginSpec struct {
 	//+kubebuilder:validation:Optional
 	DeploymentStrategy *appsv1.DeploymentStrategy `json:"deploymentStrategy,omitempty"`
 
-	// Set replicas for controller plugin's deployment. Defaults to 2
+	// Set replicas for controller plugin's deployment. Defaults to 2.
+	// On single-node clusters, the operator automatically caps the replica
+	// count to the number of available nodes when this field is not set.
 	//+kubebuilder:validation:Optional
 	//+kubebuilder:validation:Minimum:=1
+	//+kubebuilder:default:=2
 	Replicas *int32 `json:"replicas,omitempty"`
 
 	// Resource requirements for controller plugin's containers


### PR DESCRIPTION
If the replica count is not set in the CR set the replica count to 2 if the number of nodes is > 1 or if its single node cluster set the replica count to 1.

fixes: #499

