### PR TITLE
Add --audience flag to snapshot-metadata sidecar container

### DIFF
--- a/docs/features/rbd-snapshot-metadata.md
+++ b/docs/features/rbd-snapshot-metadata.md
@@ -124,7 +124,7 @@ Users need to perform the following manual setup:
 
    > **Note:**
    > - `address`: Should point to the service created in step 2, replace `<service-name>`, `<driver-namespace>`, and `<service-port>` with your actual values from step 2
-   > - `audience`: Recommended to use the CSI driver name for consistency
+   > - `audience`: Must be set to your RBD driver name (e.g., `rbd.csi.ceph.com`) as configured in the Driver CR name (step 5)
    > - `caCert`: Base64-encoded CA certificate bundle
 
 ## Ceph-CSI Operator Responsibilities

--- a/internal/controller/driver_controller.go
+++ b/internal/controller/driver_controller.go
@@ -975,6 +975,7 @@ func (r *driverReconcile) reconcileControllerPluginDeployment() error {
 											utils.CsiAddressContainerArg,
 											utils.SnapshotMetadataTlsCertArg,
 											utils.SnapshotMetadataTlsKeyArg,
+											utils.SnapshotMetadataAudienceArg(r.driver.Name),
 										},
 									),
 									Ports: []corev1.ContainerPort{

--- a/internal/utils/csi.go
+++ b/internal/utils/csi.go
@@ -409,6 +409,10 @@ var SnapshotMetadataGrpcServicePortArg = fmt.Sprintf("--port=%d", SnapshotMetada
 var SnapshotMetadataTlsCertArg = "--tls-cert=/tmp/certificates/tls.crt"
 var SnapshotMetadataTlsKeyArg = "--tls-key=/tmp/certificates/tls.key"
 
+func SnapshotMetadataAudienceArg(driverName string) string {
+	return fmt.Sprintf("--audience=%s", driverName)
+}
+
 func LogVerbosityContainerArg(level int) string {
 	return fmt.Sprintf("--v=%d", Clamp(level, 0, 5))
 }

--- a/internal/utils/csi_test.go
+++ b/internal/utils/csi_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSnapshotMetadataAudienceArg(t *testing.T) {
+	tests := []struct {
+		name       string
+		driverName string
+		expected   string
+	}{
+		{
+			name:       "rbd driver",
+			driverName: "rbd.csi.ceph.com",
+			expected:   "--audience=rbd.csi.ceph.com",
+		},
+		{
+			name:       "prefixed rbd driver",
+			driverName: "myprefix.rbd.csi.ceph.com",
+			expected:   "--audience=myprefix.rbd.csi.ceph.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SnapshotMetadataAudienceArg(tt.driverName)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Pass `--audience=<driver-name>` to the `csi-snapshot-metadata` sidecar, enabling direct audience-based `TokenReview` authentication without requiring a `SnapshotMetadataService` CR lookup
- Strengthen audience documentation from "Recommended" to "Must be set to your RBD driver name"

Ref: kubernetes-csi/external-snapshot-metadata#162

## Changes
- `internal/utils/csi.go`: Add `SnapshotMetadataAudienceArg(driverName)` helper
- `internal/controller/driver_controller.go`: Wire `--audience` into snapshot-metadata container args
- `docs/features/rbd-snapshot-metadata.md`: Clarify audience must match Driver CR name
- `internal/utils/csi_test.go`: Unit tests for `SnapshotMetadataAudienceArg`

## Test plan
- [x] Unit tests for `SnapshotMetadataAudienceArg` pass
- [x] `go build ./...` passes
- [x] Deploy on cluster with RBD driver and verify `--audience` flag appears in snapshot-metadata container args
- [x] Verify TokenReview authentication works with audience-scoped tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)