### PR TITLE
ci: use tag name instead of GIT_REF

### DIFF
--- a/.github/workflows/publish-helm-charts.yaml
+++ b/.github/workflows/publish-helm-charts.yaml
@@ -22,7 +22,9 @@ jobs:
 
       - name: Set release version
         id: release_version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+        run: echo "VERSION=${TAG_NAME#v}" >> $GITHUB_ENV
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
 
 
       - name: Install helm


### PR DESCRIPTION
The stable release publish was triggered by the release: published event, which intermittently delivers an empty github.ref (actions/runner#2788). using `github.event.release.tag_name` instead, as this is the preferred method for referencing the tag name of a release.

