### PR TITLE
remove the default replicas from validation

### DIFF
--- a/api/v1/driver_types.go
+++ b/api/v1/driver_types.go
@@ -229,12 +229,12 @@ type ControllerPluginSpec struct {
 	//+kubebuilder:validation:Optional
 	DeploymentStrategy *appsv1.DeploymentStrategy `json:"deploymentStrategy,omitempty"`
 
-	// Set replicas for controller plugin's deployment. Defaults to 2.
-	// On single-node clusters, the operator automatically caps the replica
-	// count to the number of available nodes when this field is not set.
+	// Set replicas for controller plugin's deployment.
+	// If not set, defaults to 2 or to the number of available nodes
+	// on single-node clusters. When OperatorConfig specifies a replica
+	// count, it is used as the default for all drivers.
 	//+kubebuilder:validation:Optional
 	//+kubebuilder:validation:Minimum:=1
-	//+kubebuilder:default:=2
 	Replicas *int32 `json:"replicas,omitempty"`
 
 	// Resource requirements for controller plugin's containers

--- a/config/crd/bases/csi.ceph.io_drivers.yaml
+++ b/config/crd/bases/csi.ceph.io_drivers.yaml
@@ -1076,11 +1076,11 @@ spec:
                       For example, OpenShift with SELinux restrictions requires the pod to be privileged to write to hostPath.
                     type: boolean
                   replicas:
-                    default: 2
                     description: |-
-                      Set replicas for controller plugin's deployment. Defaults to 2.
-                      On single-node clusters, the operator automatically caps the replica
-                      count to the number of available nodes when this field is not set.
+                      Set replicas for controller plugin's deployment.
+                      If not set, defaults to 2 or to the number of available nodes
+                      on single-node clusters. When OperatorConfig specifies a replica
+                      count, it is used as the default for all drivers.
                     format: int32
                     minimum: 1
                     type: integer

--- a/config/crd/bases/csi.ceph.io_operatorconfigs.yaml
+++ b/config/crd/bases/csi.ceph.io_operatorconfigs.yaml
@@ -1085,11 +1085,11 @@ spec:
                           For example, OpenShift with SELinux restrictions requires the pod to be privileged to write to hostPath.
                         type: boolean
                       replicas:
-                        default: 2
                         description: |-
-                          Set replicas for controller plugin's deployment. Defaults to 2.
-                          On single-node clusters, the operator automatically caps the replica
-                          count to the number of available nodes when this field is not set.
+                          Set replicas for controller plugin's deployment.
+                          If not set, defaults to 2 or to the number of available nodes
+                          on single-node clusters. When OperatorConfig specifies a replica
+                          count, it is used as the default for all drivers.
                         format: int32
                         minimum: 1
                         type: integer

--- a/deploy/all-in-one/install-openshift.yaml
+++ b/deploy/all-in-one/install-openshift.yaml
@@ -1459,11 +1459,11 @@ spec:
                       For example, OpenShift with SELinux restrictions requires the pod to be privileged to write to hostPath.
                     type: boolean
                   replicas:
-                    default: 2
                     description: |-
-                      Set replicas for controller plugin's deployment. Defaults to 2.
-                      On single-node clusters, the operator automatically caps the replica
-                      count to the number of available nodes when this field is not set.
+                      Set replicas for controller plugin's deployment.
+                      If not set, defaults to 2 or to the number of available nodes
+                      on single-node clusters. When OperatorConfig specifies a replica
+                      count, it is used as the default for all drivers.
                     format: int32
                     minimum: 1
                     type: integer
@@ -8672,11 +8672,11 @@ spec:
                           For example, OpenShift with SELinux restrictions requires the pod to be privileged to write to hostPath.
                         type: boolean
                       replicas:
-                        default: 2
                         description: |-
-                          Set replicas for controller plugin's deployment. Defaults to 2.
-                          On single-node clusters, the operator automatically caps the replica
-                          count to the number of available nodes when this field is not set.
+                          Set replicas for controller plugin's deployment.
+                          If not set, defaults to 2 or to the number of available nodes
+                          on single-node clusters. When OperatorConfig specifies a replica
+                          count, it is used as the default for all drivers.
                         format: int32
                         minimum: 1
                         type: integer

--- a/deploy/all-in-one/install.yaml
+++ b/deploy/all-in-one/install.yaml
@@ -1459,11 +1459,11 @@ spec:
                       For example, OpenShift with SELinux restrictions requires the pod to be privileged to write to hostPath.
                     type: boolean
                   replicas:
-                    default: 2
                     description: |-
-                      Set replicas for controller plugin's deployment. Defaults to 2.
-                      On single-node clusters, the operator automatically caps the replica
-                      count to the number of available nodes when this field is not set.
+                      Set replicas for controller plugin's deployment.
+                      If not set, defaults to 2 or to the number of available nodes
+                      on single-node clusters. When OperatorConfig specifies a replica
+                      count, it is used as the default for all drivers.
                     format: int32
                     minimum: 1
                     type: integer
@@ -8672,11 +8672,11 @@ spec:
                           For example, OpenShift with SELinux restrictions requires the pod to be privileged to write to hostPath.
                         type: boolean
                       replicas:
-                        default: 2
                         description: |-
-                          Set replicas for controller plugin's deployment. Defaults to 2.
-                          On single-node clusters, the operator automatically caps the replica
-                          count to the number of available nodes when this field is not set.
+                          Set replicas for controller plugin's deployment.
+                          If not set, defaults to 2 or to the number of available nodes
+                          on single-node clusters. When OperatorConfig specifies a replica
+                          count, it is used as the default for all drivers.
                         format: int32
                         minimum: 1
                         type: integer

--- a/deploy/charts/ceph-csi-operator/templates/driver-crd.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/driver-crd.yaml
@@ -1076,11 +1076,11 @@ spec:
                       For example, OpenShift with SELinux restrictions requires the pod to be privileged to write to hostPath.
                     type: boolean
                   replicas:
-                    default: 2
                     description: |-
-                      Set replicas for controller plugin's deployment. Defaults to 2.
-                      On single-node clusters, the operator automatically caps the replica
-                      count to the number of available nodes when this field is not set.
+                      Set replicas for controller plugin's deployment.
+                      If not set, defaults to 2 or to the number of available nodes
+                      on single-node clusters. When OperatorConfig specifies a replica
+                      count, it is used as the default for all drivers.
                     format: int32
                     minimum: 1
                     type: integer

--- a/deploy/charts/ceph-csi-operator/templates/operatorconfig-crd.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/operatorconfig-crd.yaml
@@ -1082,11 +1082,11 @@ spec:
                           For example, OpenShift with SELinux restrictions requires the pod to be privileged to write to hostPath.
                         type: boolean
                       replicas:
-                        default: 2
                         description: |-
-                          Set replicas for controller plugin's deployment. Defaults to 2.
-                          On single-node clusters, the operator automatically caps the replica
-                          count to the number of available nodes when this field is not set.
+                          Set replicas for controller plugin's deployment.
+                          If not set, defaults to 2 or to the number of available nodes
+                          on single-node clusters. When OperatorConfig specifies a replica
+                          count, it is used as the default for all drivers.
                         format: int32
                         minimum: 1
                         type: integer

--- a/deploy/multifile/crd.yaml
+++ b/deploy/multifile/crd.yaml
@@ -1450,11 +1450,11 @@ spec:
                       For example, OpenShift with SELinux restrictions requires the pod to be privileged to write to hostPath.
                     type: boolean
                   replicas:
-                    default: 2
                     description: |-
-                      Set replicas for controller plugin's deployment. Defaults to 2.
-                      On single-node clusters, the operator automatically caps the replica
-                      count to the number of available nodes when this field is not set.
+                      Set replicas for controller plugin's deployment.
+                      If not set, defaults to 2 or to the number of available nodes
+                      on single-node clusters. When OperatorConfig specifies a replica
+                      count, it is used as the default for all drivers.
                     format: int32
                     minimum: 1
                     type: integer
@@ -8663,11 +8663,11 @@ spec:
                           For example, OpenShift with SELinux restrictions requires the pod to be privileged to write to hostPath.
                         type: boolean
                       replicas:
-                        default: 2
                         description: |-
-                          Set replicas for controller plugin's deployment. Defaults to 2.
-                          On single-node clusters, the operator automatically caps the replica
-                          count to the number of available nodes when this field is not set.
+                          Set replicas for controller plugin's deployment.
+                          If not set, defaults to 2 or to the number of available nodes
+                          on single-node clusters. When OperatorConfig specifies a replica
+                          count, it is used as the default for all drivers.
                         format: int32
                         minimum: 1
                         type: integer

--- a/vendor/github.com/ceph/ceph-csi-operator/api/v1/driver_types.go
+++ b/vendor/github.com/ceph/ceph-csi-operator/api/v1/driver_types.go
@@ -229,12 +229,12 @@ type ControllerPluginSpec struct {
 	//+kubebuilder:validation:Optional
 	DeploymentStrategy *appsv1.DeploymentStrategy `json:"deploymentStrategy,omitempty"`
 
-	// Set replicas for controller plugin's deployment. Defaults to 2.
-	// On single-node clusters, the operator automatically caps the replica
-	// count to the number of available nodes when this field is not set.
+	// Set replicas for controller plugin's deployment.
+	// If not set, defaults to 2 or to the number of available nodes
+	// on single-node clusters. When OperatorConfig specifies a replica
+	// count, it is used as the default for all drivers.
 	//+kubebuilder:validation:Optional
 	//+kubebuilder:validation:Minimum:=1
-	//+kubebuilder:default:=2
 	Replicas *int32 `json:"replicas,omitempty"`
 
 	// Resource requirements for controller plugin's containers


### PR DESCRIPTION
Removing the default replica count from the CRD to ensure that we can still allow the user to deploy single controller plugin deployment on the single node cluster.

fixes: #532


Scenario | Expected Replicas | Actual Replicas | Result
-- | -- | -- | --
Driver CR without replicas, no OperatorConfig | 1 (node-count capped) | 1 | Pass
Driver CR without replicas, OperatorConfig replicas: 2 | 2 (propagated from OperatorConfig) | 2 | Pass
Driver CR with explicit replicas: 3 | 3 (user override wins) | 3 | Pass
