### PR TITLE
fix(deploy): add missing multi-yaml separator to ceph-csi-drivers chart

### DIFF
--- a/deploy/charts/ceph-csi-drivers/templates/cephConnection.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/cephConnection.yaml
@@ -1,6 +1,7 @@
 {{- $root := . -}}
 {{- range $cephConnection := .Values.cephConnections -}}
 {{- if $cephConnection.name -}}
+---
 apiVersion: csi.ceph.io/v1
 kind: CephConnection
 metadata:

--- a/deploy/charts/ceph-csi-drivers/templates/clientProfiles.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/clientProfiles.yaml
@@ -1,6 +1,7 @@
 {{- $root := . -}}
 {{- range $clientProfile := .Values.clientProfiles -}}
 {{- if $clientProfile.name -}}
+---
 apiVersion: csi.ceph.io/v1
 kind: ClientProfile
 metadata:


### PR DESCRIPTION
# Describe what this PR does #

Add YAML document separators between `CephConnection` and `ClientProfile`
resources generated by the `ceph-csi-drivers` Helm chart.

This ensures multiple entries render as separate Kubernetes resources instead
of being combined into a single YAML document.

## Is there anything that requires special attention ##

The change is backward compatible. It only affects rendering when multiple
`cephConnections` or `clientProfiles` are configured.

No external API or CRD changes are introduced.

## Related issues ##

None.

## Future concerns ##

None.