### PR TITLE
Add NetworkPolicy for operator and driver pods

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -1,11 +1,9 @@
-# v1.0.0 Pending Release Notes
+# v1.1.0 Pending Release Notes
 
 ## Breaking Changes
 
 ## Features
 
-- Added `containerExtraArgs` field to `NodePluginSpec` and `ControllerPluginSpec` to allow passing custom arguments to CSI containers. The field accepts a map where the key is the container name (e.g., `csi-rbdplugin`, `csi-provisioner`, `driver-registrar`) and the value is a list of CLI arguments. This enables customization of container behavior without modifying default operator values. The field can be configured at both the OperatorConfig level (for defaults) and Driver level (for driver-specific overrides).
-- Fencing can now be enabled in the ceph-csi-drivers Helm chart either globally for all drivers or on a per-driver basis.
-- Added `enabled` field to log rotation configuration in the ceph-csi-drivers Helm chart. Users can now disable log rotation by setting `log.rotation.enabled: false` either globally in `operatorConfig.driverSpecDefaults` or per-driver in `drivers.<driver-type>`. This resolves Helm warnings when disabling file logging from parent charts.
-- Added support to set the priorityClass in the operator helm chart.
+- Added NetworkPolicies for the operator pod and CSI driver pods (controller-plugin, csi-addons nodeplugin). Included in all generated manifests by default. Driver pod NPs are created by the operator for every reconciled driver. Node-plugin pods are exempt (`hostNetwork: true`).
+
 ## NOTE

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -18,11 +18,9 @@ resources:
 #- ../prometheus
 # [METRICS] Expose the controller manager metrics service.
 # - metrics_service.yaml
-# [NETWORK POLICY] Protect the /metrics endpoint and Webhook Server with NetworkPolicy.
-# Only Pod(s) running a namespace labeled with 'metrics: enabled' will be able to gather the metrics.
-# Only CR(s) which requires webhooks and are applied on namespaces labeled with 'webhooks: enabled' will
-# be able to communicate with the Webhook Server.
-#- ../network-policy
+# [NETWORK POLICY] Protect the operator pod with NetworkPolicy.
+# Denies all ingress and allows open egress for API server access.
+- ../network-policy
 
 #patches:
 # Uncomment the patches line if you enable Metrics

--- a/config/network-policy/kustomization.yaml
+++ b/config/network-policy/kustomization.yaml
@@ -1,2 +1,2 @@
 resources:
-- allow-metrics-traffic.yaml
+- operator-network-policy.yaml

--- a/config/network-policy/operator-network-policy.yaml
+++ b/config/network-policy/operator-network-policy.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ceph-csi-controller-manager
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: ceph-csi-op-controller-manager
+  # Ingress is not specified — deny all inbound traffic.
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -88,6 +88,18 @@ rules:
   - list
   - watch
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - storage.k8s.io
   resources:
   - csidrivers

--- a/deploy/all-in-one/install-openshift.yaml
+++ b/deploy/all-in-one/install-openshift.yaml
@@ -16969,6 +16969,21 @@ spec:
       serviceAccountName: ceph-csi-operator-controller-manager
       terminationGracePeriodSeconds: 10
 ---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ceph-csi-operator-ceph-csi-controller-manager
+  namespace: ceph-csi-operator-system
+spec:
+  egress:
+  - {}
+  podSelector:
+    matchLabels:
+      control-plane: ceph-csi-op-controller-manager
+  policyTypes:
+  - Ingress
+  - Egress
+---
 allowHostDirVolumePlugin: true
 allowHostIPC: true
 allowHostNetwork: true

--- a/deploy/all-in-one/install-openshift.yaml
+++ b/deploy/all-in-one/install-openshift.yaml
@@ -15803,6 +15803,18 @@ rules:
   - list
   - watch
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - storage.k8s.io
   resources:
   - csidrivers

--- a/deploy/all-in-one/install.yaml
+++ b/deploy/all-in-one/install.yaml
@@ -15789,6 +15789,18 @@ rules:
   - list
   - watch
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - storage.k8s.io
   resources:
   - csidrivers

--- a/deploy/all-in-one/install.yaml
+++ b/deploy/all-in-one/install.yaml
@@ -16850,3 +16850,18 @@ spec:
         runAsNonRoot: true
       serviceAccountName: ceph-csi-operator-controller-manager
       terminationGracePeriodSeconds: 10
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ceph-csi-operator-ceph-csi-controller-manager
+  namespace: ceph-csi-operator-system
+spec:
+  egress:
+  - {}
+  podSelector:
+    matchLabels:
+      control-plane: ceph-csi-op-controller-manager
+  policyTypes:
+  - Ingress
+  - Egress

--- a/deploy/charts/ceph-csi-operator/templates/manager-rbac.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/manager-rbac.yaml
@@ -89,6 +89,18 @@ rules:
   - list
   - watch
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - storage.k8s.io
   resources:
   - csidrivers

--- a/deploy/charts/ceph-csi-operator/templates/network-policy.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/network-policy.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "ceph-csi-operator.fullname" . }}-ceph-csi-controller-manager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ceph-csi-operator.labels" . | nindent 4 }}
+spec:
+  # Deny all ingress — no exposed ports.
+  # Allow open egress for API server access.
+  egress:
+  - {}
+  podSelector:
+    matchLabels:
+      control-plane: ceph-csi-op-controller-manager
+  policyTypes:
+  - Ingress
+  - Egress

--- a/deploy/multifile/operator.yaml
+++ b/deploy/multifile/operator.yaml
@@ -346,6 +346,18 @@ rules:
   - list
   - watch
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - storage.k8s.io
   resources:
   - csidrivers

--- a/docs/design/network-policy.md
+++ b/docs/design/network-policy.md
@@ -36,17 +36,17 @@ ceph-csi-operator and the CSI driver pods it manages.
      applications (Velero, etc.) can run in any namespace with any labels.
      See [CSI snapshot-metadata](https://kubernetes-csi.github.io/docs/external-snapshot-metadata.html).
 - **Egress:** Open. Required for API server and Ceph cluster access.
-- **Deleted** when no ingress rules apply (no csi-addons, no
-  snapshot-metadata).
+- When no ingress rules apply, the NP is kept with an empty ingress
+  list (deny-all ingress) for defense-in-depth.
 
 ### csi-addons Nodeplugin
 
 - **Ingress:** csi-addons controller-manager → port 9071 only.
 - **Egress:** Open.
 - **Lifecycle:** Created when `DeployCsiAddons` is true. Not created for
-  NFS drivers. The csi-addons DaemonSet is set as an owner reference —
-  when the DaemonSet is deleted (DeployCsiAddons toggled false), the NP
-  is garbage collected automatically.
+  NFS drivers. Explicitly deleted when `DeployCsiAddons` is toggled
+  false. The Driver CR is the controller owner reference for watch
+  triggers and garbage collection on Driver deletion.
 
 ### Node-Plugin DaemonSet
 

--- a/docs/design/network-policy.md
+++ b/docs/design/network-policy.md
@@ -1,0 +1,88 @@
+# NetworkPolicy for Ceph-CSI Operator and Driver Pods
+
+This document describes the NetworkPolicy implementation for the
+ceph-csi-operator and the CSI driver pods it manages.
+
+## Component Inventory
+
+| Component | Pod Labels | hostNetwork | NP Coverage |
+|---|---|---|---|
+| Operator pod | `control-plane: ceph-csi-op-controller-manager` | No | Static manifest |
+| Controller-plugin (per driver) | `app: {driver}-ctrlplugin` | Configurable | Code-generated |
+| csi-addons node agent (per driver) | `app: {driver}-nodeplugin-csi-addons` | No | Code-generated |
+| Node-plugin DaemonSet | `app: {driver}-nodeplugin` | Yes (hardcoded) | Exempt |
+
+## Policies
+
+### Operator Pod
+
+- **Ingress:** Deny all. No exposed ports (metrics disabled by default,
+  kubelet health probes bypass NetworkPolicy).
+- **Egress:** Open (`- {}`). Required for API server access. The API server
+  ClusterIP varies per cluster (10.96.0.1 on kubeadm, 172.30.0.1 on OpenShift)
+  and CNI ipBlock behavior is inconsistent across implementations, so
+  restricting egress to a specific IP is not portable.
+
+### Controller-Plugin
+
+- **Skipped** when `hostNetwork: true` (NP is exempt).
+- **Ingress** rules are conditional:
+  1. (When `DeployCsiAddons: true`) csi-addons controller-manager →
+     csi-addons gRPC port (9070 for RBD, 9080 for CephFS). Source
+     restricted to pods with labels `app.kubernetes.io/name: csi-addons`
+     and `control-plane: controller-manager` in any namespace.
+  2. (RBD only, when TLS volume `tls-key` is configured) Any pod →
+     snapshot-metadata gRPC port 50051. Open source because backup
+     applications (Velero, etc.) can run in any namespace with any labels.
+     See [CSI snapshot-metadata](https://kubernetes-csi.github.io/docs/external-snapshot-metadata.html).
+- **Egress:** Open. Required for API server and Ceph cluster access.
+- **Deleted** when no ingress rules apply (no csi-addons, no
+  snapshot-metadata).
+
+### csi-addons Nodeplugin
+
+- **Ingress:** csi-addons controller-manager → port 9071 only.
+- **Egress:** Open.
+- **Lifecycle:** Created when `DeployCsiAddons` is true. Not created for
+  NFS drivers. The csi-addons DaemonSet is set as an owner reference —
+  when the DaemonSet is deleted (DeployCsiAddons toggled false), the NP
+  is garbage collected automatically.
+
+### Node-Plugin DaemonSet
+
+No NetworkPolicy. Runs with `hostNetwork: true`, which makes it exempt
+from NetworkPolicy enforcement.
+
+## Inclusion
+
+### Static Manifest (Operator Pod)
+
+The operator pod NP is in `config/network-policy/` and referenced from
+`config/default/kustomization.yaml`. It is included in all generated
+manifests by default.
+
+### Code-Generated NPs (Driver Pods)
+
+Driver pod NPs are created unconditionally by the operator at runtime.
+The `networking.k8s.io/v1` API group has been stable since Kubernetes 1.7
+and is available on every supported cluster version.
+
+## API Server Egress Rationale
+
+Open egress (`- {}`) is used instead of restricting to a specific API server
+IP because:
+
+1. The API server ClusterIP varies per cluster and is unknown at manifest
+   authoring time.
+2. CNI implementations handle `ipBlock` inconsistently with DNAT (OVN-K8s
+   timing, Cilium quirks).
+3. HyperShift clusters may use non-standard API server ports.
+
+This follows the precedent set by
+[operator-marketplace PR #723](https://github.com/operator-framework/operator-marketplace/pull/723).
+
+## References
+
+- [CSI snapshot-metadata sidecar](https://kubernetes-csi.github.io/docs/external-snapshot-metadata.html)
+- [kubernetes-csi/external-snapshot-metadata](https://github.com/kubernetes-csi/external-snapshot-metadata)
+- [operator-marketplace NP precedent](https://github.com/operator-framework/operator-marketplace/pull/723)

--- a/docs/kubernetes-installation.md
+++ b/docs/kubernetes-installation.md
@@ -495,3 +495,23 @@ Expected output:
 ```text
 No resources found in ceph-csi-operator-system namespace.
 ```
+
+## 6. NetworkPolicies
+
+NetworkPolicies are included in all generated manifests by default.
+
+- The **operator pod** gets a policy that denies all ingress and allows open
+  egress (required for API server access).
+- Each **controller-plugin** pod gets a policy allowing ingress only from the
+  csi-addons controller-manager on the csi-addons gRPC port, and (for RBD)
+  from any pod on port 50051 for snapshot-metadata gRPC.
+- Each **csi-addons nodeplugin** pod (when `deployCsiAddons: true`) gets a
+  policy allowing ingress only from the csi-addons controller-manager on
+  port 9071.
+- The **node-plugin** DaemonSet runs with `hostNetwork: true` and is exempt
+  from NetworkPolicies.
+
+Driver pod NetworkPolicies are created by the operator for every
+reconciled driver.
+
+For design details, see [docs/design/network-policy.md](design/network-policy.md).

--- a/internal/controller/driver_controller.go
+++ b/internal/controller/driver_controller.go
@@ -32,6 +32,7 @@ import (
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -62,6 +63,7 @@ import (
 //+kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=nodes,verbs=list;watch
 //+kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
 
 type DriverType string
 
@@ -186,6 +188,10 @@ func (r *DriverReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			builder.WithPredicates(genChangedPredicate),
 		).
 		Owns(
+			&networkingv1.NetworkPolicy{},
+			builder.WithPredicates(genChangedPredicate),
+		).
+		Owns(
 			&corev1.ConfigMap{},
 			builder.MatchEveryOwner,
 			builder.WithPredicates(
@@ -241,9 +247,11 @@ func (r *driverReconcile) reconcile() error {
 		r.reconcileLogRotateConfigMap,
 		r.reconcileK8sCsiDriver,
 		r.reconcileControllerPluginDeployment,
+		r.reconcileControllerPluginNetworkPolicy,
 		r.reconcileNodePluginDaemonSet,
 		r.reconcileLivenessService,
 		r.reconcileNodePluginDaemonSetForCsiAddons,
+		r.reconcileNodePluginCsiAddonsNetworkPolicy,
 	}
 
 	// Concurrently reconcile different aspects of the clusters actual state to meet
@@ -1041,6 +1049,75 @@ func (r *driverReconcile) reconcileControllerPluginDeployment() error {
 	return err
 }
 
+func (r *driverReconcile) reconcileControllerPluginNetworkPolicy() error {
+	np := &networkingv1.NetworkPolicy{}
+	np.Name = r.generateName("ctrlplugin")
+	np.Namespace = r.driver.Namespace
+
+	pluginSpec := cmp.Or(r.driver.Spec.ControllerPlugin, &csiv1.ControllerPluginSpec{})
+	if ptr.Deref(pluginSpec.HostNetwork, false) {
+		if err := r.Delete(r.ctx, np); client.IgnoreNotFound(err) != nil {
+			return err
+		}
+		return nil
+	}
+
+	proto := corev1.ProtocolTCP
+	var ingress []networkingv1.NetworkPolicyIngressRule
+
+	if ptr.Deref(r.driver.Spec.DeployCsiAddons, false) {
+		csiAddonsPort := r.controllerPluginCsiAddonsContainerPort()
+		ingress = append(ingress, networkingv1.NetworkPolicyIngressRule{
+			From: []networkingv1.NetworkPolicyPeer{{
+				NamespaceSelector: &metav1.LabelSelector{},
+				PodSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app.kubernetes.io/name": "csi-addons",
+						"control-plane":          "controller-manager",
+					},
+				},
+			}},
+			Ports: []networkingv1.NetworkPolicyPort{
+				{Port: &intstr.IntOrString{Type: intstr.Int, IntVal: csiAddonsPort.ContainerPort}, Protocol: &proto},
+			},
+		})
+	}
+
+	if r.isRbdDriver() {
+		tlsConfigured := slices.ContainsFunc(pluginSpec.Volumes, func(vol csiv1.VolumeSpec) bool {
+			return vol.Volume.Name == "tls-key"
+		})
+		if tlsConfigured {
+			ingress = append(ingress, networkingv1.NetworkPolicyIngressRule{
+				Ports: []networkingv1.NetworkPolicyPort{
+					{Port: &intstr.IntOrString{Type: intstr.Int, IntVal: utils.SnapshotMetadataGrpcPort.ContainerPort}, Protocol: &proto},
+				},
+			})
+		}
+	}
+
+	log := r.log.WithValues("networkPolicy", np.Name)
+	log.Info("Reconciling controller plugin network policy")
+
+	opResult, err := ctrlutil.CreateOrUpdate(r.ctx, r.Client, np, func() error {
+		if err := ctrlutil.SetControllerReference(&r.driver, np, r.Scheme); err != nil {
+			return err
+		}
+		np.Spec = networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": np.Name},
+			},
+			Ingress:     ingress,
+			Egress:      []networkingv1.NetworkPolicyEgressRule{{}},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
+		}
+		return nil
+	})
+
+	logCreateOrUpdateResult(log, "NetworkPolicy", np, opResult, err)
+	return err
+}
+
 func (r *driverReconcile) controllerPluginCsiAddonsContainerPort() corev1.ContainerPort {
 	// the cephFS and rbd drivers need to use different ports
 	// to avoid port collisions with host network.
@@ -1254,6 +1331,58 @@ func (r *driverReconcile) reconcileNodePluginDaemonSetForCsiAddons() error {
 	})
 
 	logCreateOrUpdateResult(log, "csi addons node plugin daemonset", daemonSet, opResult, err)
+	return err
+}
+
+func (r *driverReconcile) reconcileNodePluginCsiAddonsNetworkPolicy() error {
+	if r.isNfsDriver() {
+		return nil
+	}
+
+	np := &networkingv1.NetworkPolicy{}
+	np.Name = r.generateName("nodeplugin-csi-addons")
+	np.Namespace = r.driver.Namespace
+
+	if !ptr.Deref(r.driver.Spec.DeployCsiAddons, false) {
+		if err := r.Delete(r.ctx, np); client.IgnoreNotFound(err) != nil {
+			return err
+		}
+		return nil
+	}
+
+	log := r.log.WithValues("networkPolicy", np.Name)
+	log.Info("Reconciling csi-addons nodeplugin network policy")
+
+	proto := corev1.ProtocolTCP
+	opResult, err := ctrlutil.CreateOrUpdate(r.ctx, r.Client, np, func() error {
+		if err := ctrlutil.SetControllerReference(&r.driver, np, r.Scheme); err != nil {
+			return err
+		}
+		np.Spec = networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": np.Name},
+			},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{{
+				From: []networkingv1.NetworkPolicyPeer{{
+					NamespaceSelector: &metav1.LabelSelector{},
+					PodSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app.kubernetes.io/name": "csi-addons",
+							"control-plane":          "controller-manager",
+						},
+					},
+				}},
+				Ports: []networkingv1.NetworkPolicyPort{
+					{Port: &intstr.IntOrString{Type: intstr.Int, IntVal: utils.NodePluginCsiAddonsContainerPort.ContainerPort}, Protocol: &proto},
+				},
+			}},
+			Egress:      []networkingv1.NetworkPolicyEgressRule{{}},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
+		}
+		return nil
+	})
+
+	logCreateOrUpdateResult(log, "NetworkPolicy", np, opResult, err)
 	return err
 }
 

--- a/test/scripts/test-upgrade-yaml.sh
+++ b/test/scripts/test-upgrade-yaml.sh
@@ -114,7 +114,7 @@ function upgrade_to_pr_version() {
 
     # Apply the upgrade
     echo "Applying PR version manifests"
-    kubectl_retry replace -f deploy/all-in-one/install.yaml
+    kubectl_retry apply --server-side --force-conflicts -f deploy/all-in-one/install.yaml
 
     # Wait a bit for the upgrade to start
     sleep 5


### PR DESCRIPTION
## Summary

- Add a static NetworkPolicy for the operator pod that denies all ingress
  and allows open egress (API server access). Included in all generated
  manifests and helm charts by default.
- Add code-generated NetworkPolicies for controller-plugin and csi-addons
  nodeplugin pods as part of the driver reconciliation loop.
- Controller-plugin NP:
  - Skipped when `hostNetwork: true` (NP exempt)
  - csi-addons gRPC ingress rule added only when `DeployCsiAddons: true`
  - Snapshot-metadata port 50051 ingress added only for RBD with TLS
    configured (`tls-key` volume present)
  - Deny-all ingress (empty rules) when no features enabled —
    defense-in-depth
- csi-addons nodeplugin NP:
  - Ingress from csi-addons controller-manager on port 9071
  - Explicitly deleted when `DeployCsiAddons` toggled false
  - Driver CR as controller owner for watch triggers and GC
- Node-plugin DaemonSet is exempt (`hostNetwork: true`).
- Fix `yaml-upgrade-test` to use `kubectl apply --server-side` instead of
  `kubectl replace` (which fails when upgrading adds new resource types).

### Why unrestricted egress (`- {}`)

All policies use open egress instead of restricting to specific IPs because
the API server `ClusterIP` is not portable:

1. **Service CIDR varies per cluster** — `10.96.0.1` (kubeadm),
   `172.30.0.1` (OpenShift), custom ranges on managed clouds.
   Unknown at manifest authoring time.
2. **CNI `ipBlock` behavior is inconsistent** — OVN-Kubernetes applies
   NetworkPolicy before or after DNAT depending on traffic direction,
   making `ipBlock`-based rules unreliable for service IPs
   ([OVN-K8s docs](https://docs.openshift.com/container-platform/latest/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.html)).
   Cilium has [similar quirks](https://github.com/cilium/cilium/issues/12277).
3. **HyperShift / non-standard ports** — HyperShift clusters expose the
   API server on non-6443 ports. Hardcoding port 6443 breaks these setups.
4. **Precedent** — OpenShift networking team guidance in
   [operator-marketplace PR #723](https://github.com/operator-framework/operator-marketplace/pull/723)
   uses open egress for the same reasons.
5. **Ceph cluster access** — Driver pods also need egress to the Ceph
   monitor/OSD network, which varies per deployment.

### References

- [CSI snapshot-metadata sidecar](https://kubernetes-csi.github.io/docs/external-snapshot-metadata.html) — port 50051 clients are backup apps (Velero)
- [kubernetes-csi/external-snapshot-metadata](https://github.com/kubernetes-csi/external-snapshot-metadata)
- [operator-marketplace NP precedent](https://github.com/operator-framework/operator-marketplace/pull/723)
- [OVN-K8s NetworkPolicy + DNAT](https://docs.openshift.com/container-platform/latest/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.html)
- [Cilium ipBlock + service DNAT issue](https://github.com/cilium/cilium/issues/12277)
- Design doc: `docs/design/network-policy.md`

## Test plan

- [x] `make build` passes
- [x] `make test` passes (existing tests)
- [x] `make build-installer` includes NP in output
- [x] Deploy operator with NP, verify pod remains Running
- [x] Create Driver CR, verify controller-plugin NP created
- [x] Toggle `DeployCsiAddons: false`, verify nodeplugin NP deleted
- [x] PVC provision (RBD + CephFS) works with NPs applied
- [x] CSIAddonsNode CRs register (gRPC connectivity through NP)

Manually tested on live OCP 4.23 cluster — PVC provision,
CSIAddonsNode registration, operator reconcile all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)