### PR TITLE
snapshot-metadata: add containerExtraArgs support

### DIFF
--- a/internal/controller/driver_controller.go
+++ b/internal/controller/driver_controller.go
@@ -968,15 +968,18 @@ func (r *driverReconcile) reconcileControllerPluginDeployment() error {
 									ImagePullPolicy: imagePullPolicy,
 									Image:           r.images["snapshot-metadata"],
 									Args: utils.DeleteZeroValues(
-										[]string{
-											utils.LogVerbosityContainerArg(logVerbosity),
-											utils.TimeoutContainerArg(grpcTimeout),
-											utils.SnapshotMetadataGrpcServicePortArg,
-											utils.CsiAddressContainerArg,
-											utils.SnapshotMetadataTlsCertArg,
-											utils.SnapshotMetadataTlsKeyArg,
-											utils.SnapshotMetadataAudienceArg(r.driver.Name),
-										},
+										append(
+											[]string{
+												utils.LogVerbosityContainerArg(logVerbosity),
+												utils.TimeoutContainerArg(grpcTimeout),
+												utils.SnapshotMetadataGrpcServicePortArg,
+												utils.CsiAddressContainerArg,
+												utils.SnapshotMetadataTlsCertArg,
+												utils.SnapshotMetadataTlsKeyArg,
+												utils.SnapshotMetadataAudienceArg(r.driver.Name),
+											},
+											utils.GetExtraArgsForContainer("csi-snapshot-metadata", pluginSpec.ContainerExtraArgs)...,
+										),
 									),
 									Ports: []corev1.ContainerPort{
 										utils.SnapshotMetadataGrpcPort,


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi-operator! -->

# Describe what this PR does #

Enable users to pass extra CLI arguments (e.g. TLS flags) to the csi-snapshot-metadata sidecar container via containerExtraArgs, matching the pattern used by all other sidecar containers.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#development-workflow)
* [ ] [Pending release notes](https://github.com/ceph/ceph-csi-operator/blob/main/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.
