### PR TITLE
Add configuration of CSI driver liveness sidecar to helm deploy and label generated services

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -5,5 +5,6 @@
 ## Features
 
 - Added NetworkPolicies for the operator pod and CSI driver pods (controller-plugin, csi-addons nodeplugin). Included in all generated manifests by default. Driver pod NPs are created by the operator for every reconciled driver. Node-plugin pods are exempt (`hostNetwork: true`).
+- The CSI driver liveness sidecar can now be configured when deploying with Helm
 
 ## NOTE

--- a/deploy/charts/ceph-csi-drivers/templates/driver.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/driver.yaml
@@ -28,6 +28,10 @@ spec:
     name: {{ $driver.imageSet.name }}
   {{- end }}
   {{- end }}
+  {{- if and $driver.liveness.metricsPort $driver.liveness.enabled }}
+  liveness:
+      metricsPort: {{ driver.liveness.metricsPort }}
+  {{- end }}
   {{- if $driver.clusterName }}
   clusterName: {{ $driver.clusterName }}
   {{- end }}

--- a/deploy/charts/ceph-csi-drivers/templates/operatorConfig.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/operatorConfig.yaml
@@ -32,6 +32,10 @@ spec:
         name: {{ $config.driverSpecDefaults.imageSet.name }}
     {{- end }}
     {{- end }}
+    {{- if and $config.driverSpecDefaults.liveness.metricsPort $config.driverSpecDefaults.liveness.enabled }}
+    liveness:
+        metricsPort: {{ $config.driverSpecDefaults.liveness.metricsPort }}
+    {{- end }}
     {{- if $config.driverSpecDefaults.clusterName }}
     clusterName: {{ $config.driverSpecDefaults.clusterName }}
     {{- end }}

--- a/deploy/charts/ceph-csi-drivers/values.yaml
+++ b/deploy/charts/ceph-csi-drivers/values.yaml
@@ -55,6 +55,11 @@ operatorConfig:
     imageSet:
       # -- ConfigMap reference to the image set for the driver (default: "")
       name: ""
+    liveness:
+      # -- Enable metrics sidecar (default: false)
+      enabled: false
+      # -- Port to expose liveness metrics (default: 8080).
+      metricsPort: 8080
     # -- Cluster name identifier (default: "")
     clusterName: ""
     # -- Flag to enable fencing (default: false)
@@ -148,6 +153,11 @@ drivers:
     imageSet:
       # -- ConfigMap reference to the image set for the driver (default: "")
       name: ""
+    liveness:
+      # -- Enable metrics sidecar (default: false)
+      enabled: false
+      # -- Port to expose liveness metrics (default: 8080).
+      metricsPort: 8080
     # -- Cluster name identifier (default: "")
     clusterName: ""
     # -- Flag to enable fencing (default: false)
@@ -231,6 +241,11 @@ drivers:
     imageSet:
       # -- ConfigMap reference to the image set for the driver (default: "")
       name: ""
+    liveness:
+      # -- Enable metrics sidecar (default: false)
+      enabled: false
+      # -- Port to expose liveness metrics (default: 8080).
+      metricsPort: 8080
     # -- Cluster name identifier (default: "")
     clusterName: ""
     # -- Flag to enable fencing (default: false)
@@ -314,6 +329,11 @@ drivers:
     imageSet:
       # -- ConfigMap reference to the image set for the driver (default: "")
       name: ""
+    liveness:
+      # -- Enable metrics sidecar (default: false)
+      enabled: false
+      # -- Port to expose liveness metrics (default: 8080).
+      metricsPort: 8080
     # -- Cluster name identifier (default: "")
     clusterName: ""
     # -- Flag to enable fencing (default: false)
@@ -397,6 +417,11 @@ drivers:
     imageSet:
       # -- ConfigMap reference to the image set for the driver (default: "")
       name: ""
+    liveness:
+      # -- Enable metrics sidecar (default: false)
+      enabled: false
+      # -- Port to expose liveness metrics (default: 8080).
+      metricsPort: 8080
     # -- Cluster name identifier (default: "")
     clusterName: ""
     # -- Flag to enable fencing (default: false)

--- a/docs/helm-charts/drivers-chart.md
+++ b/docs/helm-charts/drivers-chart.md
@@ -96,6 +96,8 @@ The following table lists the configurable parameters of the ceph-csi-drivers ch
 | `drivers.cephfs.grpcTimeout` | gRPC timeout in seconds (default: 30) | `30` |
 | `drivers.cephfs.imageSet.name` | ConfigMap reference to the image set for the driver (default: "") | `""` |
 | `drivers.cephfs.kernelMountOptions` | Kernel mount options (default: {}) | `{}` |
+| `drivers.cephfs.liveness.enabled` | Enable metrics sidecar (default: false) | `false` |
+| `drivers.cephfs.liveness.metricsPort` | Port to expose liveness metrics (default: 8080). | `8080` |
 | `drivers.cephfs.log.rotation.enabled` | Enable log rotation (default: true) | `true` |
 | `drivers.cephfs.log.rotation.logHostPath` | Default log directory path (default: "") | `""` |
 | `drivers.cephfs.log.rotation.maxFiles` | Maximum number of log files to keep (default: 7) | `7` |
@@ -132,6 +134,8 @@ The following table lists the configurable parameters of the ceph-csi-drivers ch
 | `drivers.nfs.grpcTimeout` | gRPC timeout in seconds (default: 30) | `30` |
 | `drivers.nfs.imageSet.name` | ConfigMap reference to the image set for the driver (default: "") | `""` |
 | `drivers.nfs.kernelMountOptions` | Kernel mount options (default: {}) | `{}` |
+| `drivers.nfs.liveness.enabled` | Enable metrics sidecar (default: false) | `false` |
+| `drivers.nfs.liveness.metricsPort` | Port to expose liveness metrics (default: 8080). | `8080` |
 | `drivers.nfs.log.rotation.enabled` | Enable log rotation (default: true) | `true` |
 | `drivers.nfs.log.rotation.logHostPath` | Default log directory path (default: "") | `""` |
 | `drivers.nfs.log.rotation.maxFiles` | Maximum number of log files to keep (default: 7) | `7` |
@@ -169,6 +173,8 @@ The following table lists the configurable parameters of the ceph-csi-drivers ch
 | `drivers.nvmeof.grpcTimeout` | gRPC timeout in seconds (default: 30) | `30` |
 | `drivers.nvmeof.imageSet.name` | ConfigMap reference to the image set for the driver (default: "") | `""` |
 | `drivers.nvmeof.kernelMountOptions` | Kernel mount options (default: {}) | `{}` |
+| `drivers.nvmeof.liveness.enabled` | Enable metrics sidecar (default: false) | `false` |
+| `drivers.nvmeof.liveness.metricsPort` | Port to expose liveness metrics (default: 8080). | `8080` |
 | `drivers.nvmeof.log.rotation.enabled` | Enable log rotation (default: true) | `true` |
 | `drivers.nvmeof.log.rotation.logHostPath` | Default log directory path (default: "") | `""` |
 | `drivers.nvmeof.log.rotation.maxFiles` | Maximum number of log files to keep (default: 7) | `7` |
@@ -205,6 +211,8 @@ The following table lists the configurable parameters of the ceph-csi-drivers ch
 | `drivers.rbd.grpcTimeout` | gRPC timeout in seconds (default: 30) | `30` |
 | `drivers.rbd.imageSet.name` | ConfigMap reference to the image set for the driver (default: "") | `""` |
 | `drivers.rbd.kernelMountOptions` | Kernel mount options (default: {}) | `{}` |
+| `drivers.rbd.liveness.enabled` | Enable metrics sidecar (default: false) | `false` |
+| `drivers.rbd.liveness.metricsPort` | Port to expose liveness metrics (default: 8080). | `8080` |
 | `drivers.rbd.log.rotation.enabled` | Enable log rotation (default: true) | `true` |
 | `drivers.rbd.log.rotation.logHostPath` | Default log directory path (default: "") | `""` |
 | `drivers.rbd.log.rotation.maxFiles` | Maximum number of log files to keep (default: 7) | `7` |
@@ -246,6 +254,8 @@ The following table lists the configurable parameters of the ceph-csi-drivers ch
 | `operatorConfig.driverSpecDefaults.grpcTimeout` | gRPC timeout in seconds (default: 30) | `30` |
 | `operatorConfig.driverSpecDefaults.imageSet.name` | ConfigMap reference to the image set for the driver (default: "") | `""` |
 | `operatorConfig.driverSpecDefaults.kernelMountOptions` | Kernel mount options (default: {}) | `{}` |
+| `operatorConfig.driverSpecDefaults.liveness.enabled` | Enable metrics sidecar (default: false) | `false` |
+| `operatorConfig.driverSpecDefaults.liveness.metricsPort` | Port to expose liveness metrics (default: 8080). | `8080` |
 | `operatorConfig.driverSpecDefaults.log.rotation.enabled` | Enable log rotation (default: true) | `true` |
 | `operatorConfig.driverSpecDefaults.log.rotation.logHostPath` | Default log directory path (default: "") | `""` |
 | `operatorConfig.driverSpecDefaults.log.rotation.maxFiles` | Maximum number of log files to keep (default: 7) | `7` |

--- a/internal/controller/driver_controller.go
+++ b/internal/controller/driver_controller.go
@@ -1730,6 +1730,10 @@ func (r *driverReconcile) reconcileLivenessService() error {
 	service := &corev1.Service{}
 	service.Namespace = r.driver.Namespace
 	service.Name = r.generateServiceName("liveness")
+	service.Labels = map[string]string{
+		"app":    "csi-metrics",
+		"driver": r.driver.Name,
+	}
 
 	log := r.log.WithValues("service", service.Name)
 	log.Info("Reconciling liveness service")


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi-operator! -->

# Describe what this PR does #

Adds configuration of liveness sidecar to helm deploy and label generated services

## Is there anything that requires special attention ##

Rook allows adding a ServiceMonitor for the CSI drivers. Currently this option is of no use, as there is no way to enable the liveness sidecar when deploying with Helm.

## Related issues ##

- 

## Future concerns ##

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#development-workflow)
* [x] [Pending release
  notes](https://github.com/ceph/ceph-csi-operator/blob/main/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [x] Documentation has been updated, if necessary.
* [x] Unit tests have been added, if necessary.
* [x] Integration tests have been added, if necessary.
