### PR TITLE
feat: add explict namespace to resources

### DIFF
--- a/deploy/charts/ceph-csi-drivers/templates/cephfs-ctrlplugin-r-rbac.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/cephfs-ctrlplugin-r-rbac.yaml
@@ -6,6 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ $normalizedDriverName }}-ctrlplugin-r
+  namespace: {{ $root.Release.Namespace }}
 rules:
 - apiGroups:
   - coordination.k8s.io

--- a/deploy/charts/ceph-csi-drivers/templates/cephfs-ctrlplugin-rb-rbac.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/cephfs-ctrlplugin-rb-rbac.yaml
@@ -6,6 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ $normalizedDriverName }}-ctrlplugin-rb
+  namespace: {{ $root.Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/deploy/charts/ceph-csi-drivers/templates/cephfs-nodeplugin-r-rbac.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/cephfs-nodeplugin-r-rbac.yaml
@@ -6,6 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ $normalizedDriverName }}-nodeplugin-r
+  namespace: {{ $root.Release.Namespace }}
 rules:
 - apiGroups:
   - csiaddons.openshift.io

--- a/deploy/charts/ceph-csi-drivers/templates/cephfs-nodeplugin-rb-rbac.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/cephfs-nodeplugin-rb-rbac.yaml
@@ -6,6 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ $normalizedDriverName }}-nodeplugin-rb
+  namespace: {{ $root.Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/deploy/charts/ceph-csi-drivers/templates/nvmeof-ctrlplugin-r-rbac.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/nvmeof-ctrlplugin-r-rbac.yaml
@@ -6,6 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ $normalizedDriverName }}-ctrlplugin-r
+  namespace: {{ $root.Release.Namespace }}
 rules:
 - apiGroups:
   - coordination.k8s.io

--- a/deploy/charts/ceph-csi-drivers/templates/nvmeof-ctrlplugin-rb-rbac.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/nvmeof-ctrlplugin-rb-rbac.yaml
@@ -6,6 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ $normalizedDriverName }}-ctrlplugin-rb
+  namespace: {{ $root.Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/deploy/charts/ceph-csi-drivers/templates/nvmeof-nodeplugin-r-rbac.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/nvmeof-nodeplugin-r-rbac.yaml
@@ -6,6 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ $normalizedDriverName }}-nodeplugin-r
+  namespace: {{ $root.Release.Namespace }}
 rules:
 - apiGroups:
   - csiaddons.openshift.io

--- a/deploy/charts/ceph-csi-drivers/templates/nvmeof-nodeplugin-rb-rbac.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/nvmeof-nodeplugin-rb-rbac.yaml
@@ -6,6 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ $normalizedDriverName }}-nodeplugin-rb
+  namespace: {{ $root.Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/deploy/charts/ceph-csi-drivers/templates/rbd-ctrlplugin-r-rbac.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/rbd-ctrlplugin-r-rbac.yaml
@@ -6,6 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ $normalizedDriverName }}-ctrlplugin-r
+  namespace: {{ $root.Release.Namespace }}
 rules:
 - apiGroups:
   - coordination.k8s.io

--- a/deploy/charts/ceph-csi-drivers/templates/rbd-ctrlplugin-rb-rbac.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/rbd-ctrlplugin-rb-rbac.yaml
@@ -6,6 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ $normalizedDriverName }}-ctrlplugin-rb
+  namespace: {{ $root.Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/deploy/charts/ceph-csi-drivers/templates/rbd-nodeplugin-r-rbac.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/rbd-nodeplugin-r-rbac.yaml
@@ -6,6 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ $normalizedDriverName }}-nodeplugin-r
+  namespace: {{ $root.Release.Namespace }}
 rules:
 - apiGroups:
   - csiaddons.openshift.io

--- a/deploy/charts/ceph-csi-drivers/templates/rbd-nodeplugin-rb-rbac.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/rbd-nodeplugin-rb-rbac.yaml
@@ -6,6 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ $normalizedDriverName }}-nodeplugin-rb
+  namespace: {{ $root.Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/deploy/charts/ceph-csi-operator/templates/serviceaccount.yaml
+++ b/deploy/charts/ceph-csi-operator/templates/serviceaccount.yaml
@@ -1,8 +1,10 @@
+{{- $root := . -}}
 {{ if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "ceph-csi-operator.serviceAccountName" . }}
+  namespace: {{ $root.Release.Namespace }}
   labels:
   {{- include "ceph-csi-operator.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/hack/patch-csi-operator-helm-chart.sh
+++ b/hack/patch-csi-operator-helm-chart.sh
@@ -43,6 +43,21 @@ echo "Patched $SA_FILE successfully"
 
 # Replace hardcoded namespace with Helm template variable in all template files
 if [[ "$CHART_DIR" == *"ceph-csi-operator"* ]]; then
+  echo "Restoring namespace in $SA_FILE"
+
+  awk '
+    /^metadata:/ { in_metadata = 1 }
+
+    { print }
+
+    in_metadata && /^  name: / {
+      print "  namespace: ceph-csi-operator-system"
+      in_metadata = 0
+    }
+  ' "$SA_FILE" >"${SA_FILE}.tmp"
+
+  mv "${SA_FILE}.tmp" "$SA_FILE"
+
   echo "Replacing hardcoded namespace with Helm template variable in $CHART_DIR"
 
   # Process each YAML file in the templates directory


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi-operator! -->

# Describe what this PR does #

This PR adds an explicit `namespace: {{ .Release.Namespace }}` to the metadata of all `Role` and `RoleBinding` resources in the Helm charts that were previously rendered without one.

`helm template` never injects a namespace into rendered manifests. `--namespace` flag only sets `.Release.Namespace` when present inside templates.  (see helm/helm#10737).

Tools that consume those output therefore needs to inject namespace themselves. kustomize did this until v5.8.0. Now it no longer injects the kustomization namespace into Helm-generated resources (kubernetes-sigs/kustomize#6058).  As a result, when chart is used via kustomize >= 5.8.0, the Roles/RoleBindings land in the default namespace instead of the release namespace.

Setting the namespace explicitly in the templates makes the charts independent of any namespace-injection behavior, which is the fix recommended for chart authors in the kustomize issue.

## Is there anything that requires special attention ##

Is the change backward compatible?

Yes, for all working installations. `helm install`/`helm upgrade` already places resources without an explicit namespace
  into the release namespace, so the rendered result is unchanged. kustomize < 5.8.0 with a kustomization `namespace:` overrides `metadata.namespace` regardless, so the final output is unchanged.

## Related issues ##

Refer: https://github.com/kubernetes-sigs/kustomize/issues/6058
Refer: https://github.com/helm/helm/issues/10737

## Future concerns ##

* None.

**Checklist:**

* [X] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#commit-messages).
* [X] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#development-workflow)
* [ ] [Pending release notes](https://github.com/ceph/ceph-csi-operator/blob/main/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.
