### PR TITLE
Polish and publish documentation

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -1,0 +1,54 @@
+---
+name: Publish Documentation
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch:  # allow manual run
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    if: github.repository == 'ceph/ceph-csi-operator'
+    runs-on: ubuntu-latest
+    steps:
+      # yamllint disable-line rule:line-length
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Configure Git Credentials
+        run: |
+          git config user.name ${{ secrets.CEPH_CSI_BOT_NAME }}
+          git config user.email ${{ secrets.CEPH_CSI_BOT_EMAIL }}
+
+      # yamllint disable-line rule:line-length
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: 3.x
+
+      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
+
+      # yamllint disable-line rule:line-length
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          key: mkdocs-material-${{ env.cache_id }}
+          path: ~/.cache
+          restore-keys: |
+            mkdocs-material-
+
+      # yamllint disable-line rule:line-length
+      - run: pip install mkdocs-material==9.7.7
+
+      - name: Preserve non-docs files from gh-pages
+        run: |
+          mkdir -p site
+          git fetch origin gh-pages 2>/dev/null || true
+          git show origin/gh-pages:index.yaml > site/index.yaml 2>/dev/null || true
+
+      - run: mkdocs gh-deploy --force --dirty --verbose

--- a/.github/workflows/verify-docs.yaml
+++ b/.github/workflows/verify-docs.yaml
@@ -1,0 +1,19 @@
+---
+name: Verify Documentation
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+
+jobs:
+  verify-docs-nav:
+    runs-on: ubuntu-latest
+    steps:
+      # yamllint disable-line rule:line-length
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Verify documentation navigation
+        run: make verify-docs-nav

--- a/Makefile
+++ b/Makefile
@@ -325,6 +325,27 @@ $(KUSTOMIZE): $(LOCALBIN)
 	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v5,$(KUSTOMIZE_VERSION))
 
 .PHONY: controller-gen
+
+.PHONY: verify-docs-nav
+verify-docs-nav: ## Verify all design and feature docs are included in mkdocs.yml navigation
+	@echo "Checking Design section..."
+	@for file in docs/design/*.md; do \
+		filename=$$(basename $$file); \
+		if ! grep -q "design/$$filename" mkdocs.yml; then \
+			echo "ERROR: $$filename is not referenced in mkdocs.yml Design section"; \
+			exit 1; \
+		fi; \
+	done
+	@echo "Checking Features section..."
+	@for file in docs/features/*.md; do \
+		filename=$$(basename $$file); \
+		if ! grep -q "features/$$filename" mkdocs.yml; then \
+			echo "ERROR: $$filename is not referenced in mkdocs.yml Features section"; \
+			exit 1; \
+		fi; \
+	done
+	@echo "All documentation files are properly referenced in mkdocs.yml"
+
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
 $(CONTROLLER_GEN): $(LOCALBIN)
 	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen,$(CONTROLLER_TOOLS_VERSION))

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,40 @@
+# Ceph CSI Operator
+
+## Overview
+
+The Ceph CSI Operator provides native management interfaces for [Ceph-CSI drivers (CephFS, RBD, and NFS)](https://github.com/ceph/ceph-csi) for Kubernetes and OpenShift environments. The operator automates the deployment, configuration, and management of these drivers using new Kubernetes APIs defined as a set of Custom Resource Definitions (CRDs).
+
+**Platform Support:**
+
+- Kubernetes 1.32+
+- OpenShift 4.19+
+
+## Quick Start
+
+For those eager to get started quickly, follow the steps outlined in the [Quick Start Guide](quick-start.md).
+
+## Installation
+
+For detailed installation instructions, including methods using Helm and manual deployment, please visit the [Installation Guide](installation.md).
+
+## Contributing
+
+We welcome contributions to the Ceph CSI Operator! Please follow the [Development Guide](development-guide.md) and [Coding Conventions](coding.md) if you are interested to contribute to this repo.
+
+### Reporting Issues
+
+If you encounter a problem, please [open an issue](https://github.com/ceph/ceph-csi-operator/issues) on GitHub. Be sure to fill the template when opening an issue.
+
+### Pull Requests
+
+We encourage you to submit pull requests for bug fixes, improvements, or new features. Please ensure that your code adheres to our coding standards and includes tests where applicable.
+
+## License
+
+The Ceph CSI Operator is licensed under the Apache License 2.0. See the [LICENSE](https://github.com/ceph/ceph-csi-operator/blob/main/LICENSE) file for more details.
+
+## Contact
+
+Please use the following to reach members of the community:
+
+- **Slack**: Join the [#ceph-csi](https://ceph-storage.slack.com/archives/C05522L7P60) channel on the [Ceph Slack](https://ceph-storage.slack.com) to discuss anything related to this project. You can join the Slack by this [invite link](https://bit.ly/ceph-slack-invite)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,63 @@
+---
+site_name: Ceph-CSI Operator Documentation
+site_description: Kubernetes Operator for managing Ceph-CSI drivers
+site_author: Ceph-CSI Operator Contributors
+site_url: https://ceph.github.io/ceph-csi-operator
+
+repo_name: ceph/ceph-csi-operator
+repo_url: https://github.com/ceph/ceph-csi-operator
+
+theme:
+  name: material
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.tabbed:
+      alternate_style: true
+  - tables
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Getting Started:
+      - Quick Start: quick-start.md
+      - Installation: installation.md
+      - Kubernetes Installation: kubernetes-installation.md
+  - Design:
+      - Operator Architecture: design/operator.md
+      - Host Network: design/hostNetwork.md
+      - Log Rotation: design/logrotate.md
+      - Network Policy: design/network-policy.md
+      - Replication: design/replication.md
+  - Features:
+      - RBD Snapshot Metadata: features/rbd-snapshot-metadata.md
+  - Helm Charts:
+      - Overview: helm-charts/helm-charts.md
+      - Operator Chart: helm-charts/operator-chart.md
+      - Drivers Chart: helm-charts/drivers-chart.md
+  - Operations:
+      - Migration: migration.md
+      - Custom Images: custom-images.md
+  - Contributing:
+      - Development Guide: development-guide.md
+      - Coding Conventions: coding.md
+      - Releases: releases.md
+      - DCO: DCO


### PR DESCRIPTION
The documentation is published by pushing the change to the gh-pages branch.
This then triggers a standard GitHub workflow that makes the pages available on
https://ceph.github.io/ceph-csi-operator/

Generation of the documentation is done with mkdocs-material, similar to how
Ceph-CSI and Rook do it.

The Helm Charts (index.yaml) is retained while the gh-pages branch is pushed.
This is required for being able to provide the Helm Charts which are downloaded
from the GitHub releases page.

When a new release is made, the Helm Chart registry is updated, and the
documentation is regenerated as well.