### PR TITLE
docs: fix drivers chart Helm repository

### DIFF
--- a/docs/helm-charts/drivers-chart.gotmpl.md
+++ b/docs/helm-charts/drivers-chart.gotmpl.md
@@ -33,7 +33,7 @@ ceph-csi-drivers currently publishes artifacts of the ceph-csi drivers to tagged
 
 
 ```console
-helm repo add ceph-csi-operator https://ceph.github.io/ceph-csi-operator-charts
+helm repo add ceph-csi-operator https://ceph.github.io/ceph-csi-operator/
 helm install ceph-csi-drivers --create-namespace --namespace ceph-csi-driver ceph-csi-operator/ceph-csi-drivers
 ```
 
@@ -44,7 +44,7 @@ For example settings, see the next section or [values.yaml](https://github.com/c
 For OpenShift clusters, you must enable OpenShift support and configure the SCC ClusterRole name to match the operator installation:
 
 ```console
-helm repo add ceph-csi-operator https://ceph.github.io/ceph-csi-operator-charts
+helm repo add ceph-csi-operator https://ceph.github.io/ceph-csi-operator/
 helm install ceph-csi-drivers --create-namespace --namespace ceph-csi-driver \
   --set openshift.enabled=true \
   --set openshift.sccClusterRoleName=ceph-csi-operator-scc-user \

--- a/docs/helm-charts/drivers-chart.md
+++ b/docs/helm-charts/drivers-chart.md
@@ -34,7 +34,7 @@ ceph-csi-drivers currently publishes artifacts of the ceph-csi drivers to tagged
 ### **Released version**
 
 ```console
-helm repo add ceph-csi-operator https://ceph.github.io/ceph-csi-operator-charts
+helm repo add ceph-csi-operator https://ceph.github.io/ceph-csi-operator/
 helm install ceph-csi-drivers --create-namespace --namespace ceph-csi-driver ceph-csi-operator/ceph-csi-drivers
 ```
 
@@ -45,7 +45,7 @@ For example settings, see the next section or [values.yaml](https://github.com/c
 For OpenShift clusters, you must enable OpenShift support and configure the SCC ClusterRole name to match the operator installation:
 
 ```console
-helm repo add ceph-csi-operator https://ceph.github.io/ceph-csi-operator-charts
+helm repo add ceph-csi-operator https://ceph.github.io/ceph-csi-operator/
 helm install ceph-csi-drivers --create-namespace --namespace ceph-csi-driver \
   --set openshift.enabled=true \
   --set openshift.sccClusterRoleName=ceph-csi-operator-scc-user \


### PR DESCRIPTION
# Describe what this PR does

Updates the drivers chart installation examples to use the published Ceph CSI Operator Helm repository.

## Is there anything that requires special attention

No. The change is backward compatible and documentation-only.

## Related issues

Fixes: #565

## Future concerns

None.

**Checklist:**

* [x] Commit title and message follow the developer guide
* [x] Reviewed the developer guide on submitting a pull request
* [x] Pending release notes are not required for this documentation correction
* [x] Documentation has been updated
* [x] Unit tests are not necessary for this documentation correction
* [x] Integration tests are not necessary for this documentation correction

Validation: `make generate-helm-docs` reproduced the rendered file, `git diff --check` passed, and the corrected Helm `index.yaml` returns HTTP 200.
