### PR TITLE
rbac: add watch verb for volumesnapshots in cephfs and nfs ctrlplugin

### DIFF
--- a/config/csi-rbac/cephfs_ctrlplugin_cluster_role.yaml
+++ b/config/csi-rbac/cephfs_ctrlplugin_cluster_role.yaml
@@ -38,7 +38,7 @@ rules:
     verbs: ["patch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotclasses"]
     verbs: ["get", "list", "watch"]

--- a/config/csi-rbac/nfs_ctrlplugin_cluster_role.yaml
+++ b/config/csi-rbac/nfs_ctrlplugin_cluster_role.yaml
@@ -39,7 +39,7 @@ rules:
     verbs: ["update", "patch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims/status"]
     verbs: ["patch"]

--- a/deploy/all-in-one/install-openshift.yaml
+++ b/deploy/all-in-one/install-openshift.yaml
@@ -15490,6 +15490,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -16149,6 +16150,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/deploy/all-in-one/install.yaml
+++ b/deploy/all-in-one/install.yaml
@@ -15476,6 +15476,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -16135,6 +16136,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/deploy/charts/ceph-csi-drivers/templates/cephfs-ctrlplugin-cr-rbac.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/cephfs-ctrlplugin-cr-rbac.yaml
@@ -105,6 +105,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:

--- a/deploy/charts/ceph-csi-drivers/templates/nfs-ctrlplugin-cr-rbac.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/nfs-ctrlplugin-cr-rbac.yaml
@@ -113,6 +113,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/deploy/multifile/csi-rbac.yaml
+++ b/deploy/multifile/csi-rbac.yaml
@@ -404,6 +404,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -692,6 +693,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
## Summary
- CephFS and NFS ctrlplugin ClusterRoles only had `get` and `list` for `volumesnapshots`, missing `watch`.
- The `csi-provisioner` sidecar's `snapshot_finalizer_controller` reflector watches `VolumeSnapshot` resources, causing repeated "Failed to watch" errors.
- RBD ctrlplugin already had `["get", "list", "watch"]` — this aligns CephFS and NFS to match.
- Updated source YAML files and generated `deploy/multifile/csi-rbac.yaml`.

Observed in CI logs: https://jenkins-ceph-csi.apps.ocp.cloud.ci.centos.org/blue/rest/organizations/jenkins/pipelines/mini-e2e-operator_k8s-1.36/runs/2/nodes/104/log/?start=0

## Test plan
- [ ] Deploy operator — verify no "Failed to watch volumesnapshots" errors in csi-provisioner logs for CephFS/NFS
- [ ] Verify CephFS and NFS ctrlplugin ClusterRoles include `watch` for `volumesnapshots`

🤖 Generated with [Claude Code](https://claude.com/claude-code)