### PR TITLE
ci: correct passing Ceph-CSI Bot username when publishing docs

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Configure Git Credentials
         run: |
-          git config user.name ${{ secrets.CEPH_CSI_BOT_NAME }}
+          git config user.name ${{ secrets.CEPH_CSI_BOT_USER }}
           git config user.email ${{ secrets.CEPH_CSI_BOT_EMAIL }}
 
       # yamllint disable-line rule:line-length


### PR DESCRIPTION
The secret in GitHub settings is CEPH_CSI_BOT_USER, like in the job where the Helm Charts are published. Not CEPH_CSI_BOT_NAME as used in the Ceph-CSI repository.