### PR TITLE
fix(helm): omit unset rbd mirror daemon count

### DIFF
--- a/deploy/charts/ceph-csi-drivers/templates/cephConnection.yaml
+++ b/deploy/charts/ceph-csi-drivers/templates/cephConnection.yaml
@@ -12,7 +12,9 @@ spec:
   {{- range $cephConnection.monitors }}
   - {{ . }}
   {{- end }}
-  rbdMirrorDaemonCount: {{ $cephConnection.rbdMirrorDaemonCount }}
+  {{- with $cephConnection.rbdMirrorDaemonCount }}
+  rbdMirrorDaemonCount: {{ . }}
+  {{- end }}
   {{- with $cephConnection.crushLocationLabels }}
   readAffinity:
     crushLocationLabels:


### PR DESCRIPTION
## Summary

When a `cephConnections` entry omits `rbdMirrorDaemonCount`, the chart currently renders `rbdMirrorDaemonCount: null`. Kubernetes rejects that value because the CRD field is an optional integer with a minimum of 1.

Render the field only when a value is supplied. Existing positive values are unchanged, while omitted values now let the CRD/operator default apply.

## Testing

- Rendered the chart with an unset value and confirmed the field is omitted.
- Rendered the chart with `rbdMirrorDaemonCount=2` and confirmed the field remains `2`.
- `git diff --check`

Fixes #551
