### PR TITLE
Update golangci lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,31 +1,15 @@
+version: "2"
+
 run:
   timeout: 5m
   allow-parallel-runners: true
 
-issues:
-  # don't skip warning about doc comments
-  # don't exclude the default set of lint
-  exclude-use-default: false
-  # restore some of the defaults
-  # (fill in the rest as needed)
-  exclude-rules:
-    - path: "api/*"
-      linters:
-        - lll
-    - path: "internal/*"
-      linters:
-        - dupl
-        - lll
 linters:
-  disable-all: true
+  default: none
   enable:
     - dupl
     - errcheck
-    - exportloopref
     - goconst
-    - gofmt
-    - goimports
-    - gosimple
     - govet
     - gosec
     - ineffassign
@@ -34,7 +18,25 @@ linters:
     - nakedret
     - prealloc
     - staticcheck
-    - typecheck
     - unconvert
     - unparam
     - unused
+
+  exclusions:
+    # don't exclude the default set of lint
+    presets: []
+    # restore some of the defaults
+    # (fill in the rest as needed)
+    rules:
+      - path: "api/*"
+        linters:
+          - lll
+      - path: "internal/*"
+        linters:
+          - dupl
+          - lll
+
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ markdownlint-fix:
 
 .PHONY:	golangci-lint-fix
 golangci-lint-fix: $(GOLANGCI_LINT) ## Run the golangci-lint linter and perform fixes
-	@$(GOLANGCI_LINT) --config=.golangci.yml -verbose run --fix
+	@$(GOLANGCI_LINT) --config=.golangci.yml --verbose run --fix
 
 
 .PHONY: lint
@@ -305,7 +305,7 @@ HELM_DOCS ?= $(LOCALBIN)/helm-docs-$(HELM_DOCS_VERSION)
 KUSTOMIZE_VERSION ?= v5.3.0
 CONTROLLER_TOOLS_VERSION ?= v0.17.2
 ENVTEST_VERSION ?= v0.0.0-20250517180713-32e5e9e948a5
-GOLANGCI_LINT_VERSION ?= v1.63.4
+GOLANGCI_LINT_VERSION ?= v2.13.2
 HELMIFY_VERSION ?= v0.4.20
 HELM_DOCS_VERSION ?= v1.14.2
 
@@ -361,9 +361,9 @@ check-all-committed: ## Fail in case there are uncommitted changes
 
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Run the golangci-lint linter
-	@$(GOLANGCI_LINT) --config=.golangci.yml -verbose run
+	@$(GOLANGCI_LINT) --config=.golangci.yml --verbose run
 $(GOLANGCI_LINT): $(LOCALBIN) ## Download golangci-lint locally if necessary.
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,${GOLANGCI_LINT_VERSION})
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,${GOLANGCI_LINT_VERSION})
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary (ideally with version)

--- a/internal/controller/clientprofile_controller_test.go
+++ b/internal/controller/clientprofile_controller_test.go
@@ -33,6 +33,12 @@ import (
 	csiv1 "github.com/ceph/ceph-csi-operator/api/v1"
 )
 
+const (
+	defaultNamespace  = "default"
+	remoteProfileName = "remote-profile"
+	acceptedMessage   = "accepted"
+)
+
 var _ = Describe("ClientProfile Controller with Fake Client", func() {
 	var (
 		ctx                context.Context
@@ -55,7 +61,7 @@ var _ = Describe("ClientProfile Controller with Fake Client", func() {
 		testCephConnection = &csiv1.CephConnection{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-ceph-connection",
-				Namespace: "default",
+				Namespace: defaultNamespace,
 			},
 			Spec: csiv1.CephConnectionSpec{
 				Monitors: []string{"mon1:6789", "mon2:6789"},
@@ -65,7 +71,7 @@ var _ = Describe("ClientProfile Controller with Fake Client", func() {
 		testClientProfile = &csiv1.ClientProfile{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-client-profile",
-				Namespace: "default",
+				Namespace: defaultNamespace,
 			},
 			Spec: csiv1.ClientProfileSpec{
 				CephConnectionRef: corev1.LocalObjectReference{
@@ -117,11 +123,11 @@ var _ = Describe("ClientProfile Controller with Fake Client", func() {
 			cpr := &csiv1.ClientProfileReplication{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-replication",
-					Namespace: "default",
+					Namespace: defaultNamespace,
 				},
 				Spec: csiv1.ClientProfileReplicationSpec{
 					LocalClientProfile:  testClientProfile.Name,
-					RemoteClientProfile: "remote-profile",
+					RemoteClientProfile: remoteProfileName,
 					RBD: &csiv1.RBDReplicationSpec{
 						PoolMapping: []csiv1.PoolMappingSpec{
 							{Name: "rbd", RemoteID: "5"},
@@ -130,7 +136,7 @@ var _ = Describe("ClientProfile Controller with Fake Client", func() {
 				},
 				Status: csiv1.ClientProfileReplicationStatus{
 					Phase:   csiv1.ClientProfileReplicationPhaseReady,
-					Message: "accepted",
+					Message: acceptedMessage,
 				},
 			}
 			Expect(fakeClient.Create(ctx, cpr)).To(Succeed())
@@ -156,7 +162,7 @@ var _ = Describe("ClientProfile Controller with Fake Client", func() {
 			cpr1 := &csiv1.ClientProfileReplication{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-replication-1",
-					Namespace: "default",
+					Namespace: defaultNamespace,
 				},
 				Spec: csiv1.ClientProfileReplicationSpec{
 					LocalClientProfile:  testClientProfile.Name,
@@ -164,7 +170,7 @@ var _ = Describe("ClientProfile Controller with Fake Client", func() {
 				},
 				Status: csiv1.ClientProfileReplicationStatus{
 					Phase:   csiv1.ClientProfileReplicationPhaseReady,
-					Message: "accepted",
+					Message: acceptedMessage,
 				},
 			}
 			Expect(fakeClient.Create(ctx, cpr1)).To(Succeed())
@@ -172,7 +178,7 @@ var _ = Describe("ClientProfile Controller with Fake Client", func() {
 			cpr2 := &csiv1.ClientProfileReplication{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-replication-2",
-					Namespace: "default",
+					Namespace: defaultNamespace,
 				},
 				Spec: csiv1.ClientProfileReplicationSpec{
 					LocalClientProfile:  testClientProfile.Name,
@@ -180,7 +186,7 @@ var _ = Describe("ClientProfile Controller with Fake Client", func() {
 				},
 				Status: csiv1.ClientProfileReplicationStatus{
 					Phase:   csiv1.ClientProfileReplicationPhaseReady,
-					Message: "accepted",
+					Message: acceptedMessage,
 				},
 			}
 			Expect(fakeClient.Create(ctx, cpr2)).To(Succeed())
@@ -203,7 +209,7 @@ var _ = Describe("ClientProfile Controller with Fake Client", func() {
 			deletingProfile := &csiv1.ClientProfile{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "deleting-profile",
-					Namespace:         "default",
+					Namespace:         defaultNamespace,
 					DeletionTimestamp: &now,
 					Finalizers:        []string{cleanupFinalizer},
 				},
@@ -217,11 +223,11 @@ var _ = Describe("ClientProfile Controller with Fake Client", func() {
 			cpr := &csiv1.ClientProfileReplication{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-replication",
-					Namespace: "default",
+					Namespace: defaultNamespace,
 				},
 				Spec: csiv1.ClientProfileReplicationSpec{
 					LocalClientProfile:  deletingProfile.Name,
-					RemoteClientProfile: "remote-profile",
+					RemoteClientProfile: remoteProfileName,
 				},
 			}
 

--- a/internal/controller/clientprofilemapping_controller_test.go
+++ b/internal/controller/clientprofilemapping_controller_test.go
@@ -38,7 +38,7 @@ var _ = Describe("ClientProfileMapping Controller", func() {
 
 		typeNamespacedName := types.NamespacedName{
 			Name:      resourceName,
-			Namespace: "default", // TODO(user):Modify as needed
+			Namespace: defaultNamespace, // TODO(user):Modify as needed
 		}
 		clientprofilemapping := &csiv1.ClientProfileMapping{}
 
@@ -49,7 +49,7 @@ var _ = Describe("ClientProfileMapping Controller", func() {
 				resource := &csiv1.ClientProfileMapping{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      resourceName,
-						Namespace: "default",
+						Namespace: defaultNamespace,
 					},
 					Spec: csiv1.ClientProfileMappingSpec{
 						Mappings: []csiv1.MappingsSpec{

--- a/internal/controller/clientprofilereplication_controller_test.go
+++ b/internal/controller/clientprofilereplication_controller_test.go
@@ -56,7 +56,7 @@ var _ = Describe("ClientProfileReplication Controller with Fake Client", func() 
 		testCephConnection = &csiv1.CephConnection{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-ceph-connection",
-				Namespace: "default",
+				Namespace: defaultNamespace,
 			},
 			Spec: csiv1.CephConnectionSpec{
 				Monitors: []string{"mon1:6789", "mon2:6789"},
@@ -66,7 +66,7 @@ var _ = Describe("ClientProfileReplication Controller with Fake Client", func() 
 		testClientProfile = &csiv1.ClientProfile{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-client-profile",
-				Namespace: "default",
+				Namespace: defaultNamespace,
 			},
 			Spec: csiv1.ClientProfileSpec{
 				CephConnectionRef: corev1.LocalObjectReference{
@@ -100,11 +100,11 @@ var _ = Describe("ClientProfileReplication Controller with Fake Client", func() 
 			cpr := &csiv1.ClientProfileReplication{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-cpr-no-profile",
-					Namespace: "default",
+					Namespace: defaultNamespace,
 				},
 				Spec: csiv1.ClientProfileReplicationSpec{
 					LocalClientProfile:  "nonexistent-profile",
-					RemoteClientProfile: "remote-profile",
+					RemoteClientProfile: remoteProfileName,
 				},
 			}
 			Expect(fakeClient.Create(ctx, cpr)).To(Succeed())
@@ -134,11 +134,11 @@ var _ = Describe("ClientProfileReplication Controller with Fake Client", func() 
 			cpr := &csiv1.ClientProfileReplication{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-cpr-single",
-					Namespace: "default",
+					Namespace: defaultNamespace,
 				},
 				Spec: csiv1.ClientProfileReplicationSpec{
 					LocalClientProfile:  testClientProfile.Name,
-					RemoteClientProfile: "remote-profile",
+					RemoteClientProfile: remoteProfileName,
 					RBD: &csiv1.RBDReplicationSpec{
 						PoolMapping: []csiv1.PoolMappingSpec{
 							{Name: "rbd", RemoteID: "5"},
@@ -177,7 +177,7 @@ var _ = Describe("ClientProfileReplication Controller with Fake Client", func() 
 			cpr1 := &csiv1.ClientProfileReplication{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "test-cpr-oldest",
-					Namespace:         "default",
+					Namespace:         defaultNamespace,
 					CreationTimestamp: oldTime,
 				},
 				Spec: csiv1.ClientProfileReplicationSpec{
@@ -189,7 +189,7 @@ var _ = Describe("ClientProfileReplication Controller with Fake Client", func() 
 			cpr2 := &csiv1.ClientProfileReplication{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "test-cpr-newer",
-					Namespace:         "default",
+					Namespace:         defaultNamespace,
 					CreationTimestamp: newTime,
 				},
 				Spec: csiv1.ClientProfileReplicationSpec{

--- a/internal/controller/driver_controller.go
+++ b/internal/controller/driver_controller.go
@@ -81,6 +81,15 @@ const (
 	driverCSIAddonsFeatureVolumeCondition = "addons.csi.ceph.io/volume-condition"
 
 	logRotateCmd = `while true; do logrotate --verbose /logrotate-config/csi; sleep 15m; done`
+
+	// Label and container names
+	appLabelKey         = "app"
+	csiAddonsContainer  = "csi-addons"
+	logRotatorContainer = "log-rotator"
+	bashShell           = "/bin/bash"
+
+	// Capability constants
+	capabilityAll = "All"
 )
 
 // A regexp used to parse driver's prefix and type from the full name
@@ -537,7 +546,7 @@ func (r *driverReconcile) reconcileControllerPluginDeployment() error {
 
 		appName := deploy.Name
 		appSelector := metav1.LabelSelector{
-			MatchLabels: map[string]string{"app": appName},
+			MatchLabels: map[string]string{appLabelKey: appName},
 		}
 
 		leaderElectionSpec := cmp.Or(r.driver.Spec.LeaderElection, &defaultLeaderElection)
@@ -558,7 +567,7 @@ func (r *driverReconcile) reconcileControllerPluginDeployment() error {
 			&corev1.SecurityContext{
 				Privileged: pluginSpec.Privileged,
 				Capabilities: &corev1.Capabilities{
-					Drop: []corev1.Capability{"All"},
+					Drop: []corev1.Capability{capabilityAll},
 				},
 			},
 			nil,
@@ -586,7 +595,7 @@ func (r *driverReconcile) reconcileControllerPluginDeployment() error {
 					Labels: utils.Call(func() map[string]string {
 						podLabels := map[string]string{}
 						maps.Copy(podLabels, pluginSpec.Labels)
-						podLabels["app"] = appName
+						podLabels[appLabelKey] = appName
 						return podLabels
 					}),
 					Annotations: maps.Clone(pluginSpec.Annotations),
@@ -814,7 +823,7 @@ func (r *driverReconcile) reconcileControllerPluginDeployment() error {
 								SecurityContext: &corev1.SecurityContext{
 									Privileged: ptr.To(true),
 									Capabilities: &corev1.Capabilities{
-										Drop: []corev1.Capability{"All"},
+										Drop: []corev1.Capability{capabilityAll},
 									},
 								},
 								Args: utils.DeleteZeroValues(
@@ -844,7 +853,7 @@ func (r *driverReconcile) reconcileControllerPluginDeployment() error {
 						if r.withCsiAddons() {
 							port := r.controllerPluginCsiAddonsContainerPort()
 							containers = append(containers, corev1.Container{
-								Name:            "csi-addons",
+								Name:            csiAddonsContainer,
 								Image:           r.images["addons"],
 								ImagePullPolicy: imagePullPolicy,
 								SecurityContext: logRotateSecurityContext,
@@ -859,9 +868,9 @@ func (r *driverReconcile) reconcileControllerPluginDeployment() error {
 											utils.CsiAddonsAddressContainerArg,
 											utils.ContainerPortArg(port),
 											utils.NamespaceContainerArg,
-											utils.If(logRotationEnabled, utils.LogFileContainerArg("csi-addons"), ""),
+											utils.If(logRotationEnabled, utils.LogFileContainerArg(csiAddonsContainer), ""),
 										),
-										utils.GetExtraArgsForContainer("csi-addons", pluginSpec.ContainerExtraArgs)...,
+										utils.GetExtraArgsForContainer(csiAddonsContainer, pluginSpec.ContainerExtraArgs)...,
 									),
 								),
 								Ports: []corev1.ContainerPort{
@@ -954,12 +963,12 @@ func (r *driverReconcile) reconcileControllerPluginDeployment() error {
 						if logRotationEnabled {
 							resources := ptr.Deref(pluginSpec.Resources.LogRotator, corev1.ResourceRequirements{})
 							containers = append(containers, corev1.Container{
-								Name:            "log-rotator",
+								Name:            logRotatorContainer,
 								Image:           r.images["plugin"],
 								ImagePullPolicy: imagePullPolicy,
 								Resources:       resources,
 								SecurityContext: logRotateSecurityContext,
-								Command:         []string{"/bin/bash", "-c", logRotateCmd},
+								Command:         []string{bashShell, "-c", logRotateCmd},
 								VolumeMounts: []corev1.VolumeMount{
 									utils.LogsDirVolumeMount,
 									utils.LogRotateDirVolumeMount,
@@ -1076,7 +1085,7 @@ func (r *driverReconcile) reconcileControllerPluginNetworkPolicy() error {
 				NamespaceSelector: &metav1.LabelSelector{},
 				PodSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
-						"app.kubernetes.io/name": "csi-addons",
+						"app.kubernetes.io/name": csiAddonsContainer,
 						"control-plane":          "controller-manager",
 					},
 				},
@@ -1109,7 +1118,7 @@ func (r *driverReconcile) reconcileControllerPluginNetworkPolicy() error {
 		}
 		np.Spec = networkingv1.NetworkPolicySpec{
 			PodSelector: metav1.LabelSelector{
-				MatchLabels: map[string]string{"app": np.Name},
+				MatchLabels: map[string]string{appLabelKey: np.Name},
 			},
 			Ingress:     ingress,
 			Egress:      []networkingv1.NetworkPolicyEgressRule{{}},
@@ -1193,7 +1202,7 @@ func (r *driverReconcile) reconcileNodePluginDaemonSetForCsiAddons() error {
 
 		daemonSet.Spec = appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"app": appName},
+				MatchLabels: map[string]string{appLabelKey: appName},
 			},
 			UpdateStrategy: ptr.Deref(pluginSpec.UpdateStrategy, defaultDaemonSetUpdateStrategy),
 			Template: corev1.PodTemplateSpec{
@@ -1201,7 +1210,7 @@ func (r *driverReconcile) reconcileNodePluginDaemonSetForCsiAddons() error {
 					Labels: utils.Call(func() map[string]string {
 						podLabels := map[string]string{}
 						maps.Copy(podLabels, pluginSpec.Labels)
-						podLabels["app"] = appName
+						podLabels[appLabelKey] = appName
 						return podLabels
 					}),
 					Annotations: maps.Clone(pluginSpec.Annotations),
@@ -1217,7 +1226,7 @@ func (r *driverReconcile) reconcileNodePluginDaemonSetForCsiAddons() error {
 					Containers: utils.Call(func() []corev1.Container {
 						containers := []corev1.Container{
 							{
-								Name:            "csi-addons",
+								Name:            csiAddonsContainer,
 								Image:           r.images["addons"],
 								ImagePullPolicy: imagePullPolicy,
 								// We need this in order for this container to be able to access
@@ -1226,7 +1235,7 @@ func (r *driverReconcile) reconcileNodePluginDaemonSetForCsiAddons() error {
 								SecurityContext: &corev1.SecurityContext{
 									Privileged: ptr.To(true),
 									Capabilities: &corev1.Capabilities{
-										Drop: []corev1.Capability{"All"},
+										Drop: []corev1.Capability{capabilityAll},
 									},
 								},
 								Args: utils.DeleteZeroValues(
@@ -1280,17 +1289,17 @@ func (r *driverReconcile) reconcileNodePluginDaemonSetForCsiAddons() error {
 						if logRotationEnabled {
 							resources := ptr.Deref(pluginSpec.Resources.LogRotator, corev1.ResourceRequirements{})
 							containers = append(containers, corev1.Container{
-								Name:            "log-rotator",
+								Name:            logRotatorContainer,
 								Image:           r.images["plugin"],
 								ImagePullPolicy: imagePullPolicy,
 								Resources:       resources,
 								SecurityContext: &corev1.SecurityContext{
 									Privileged: ptr.To(true),
 									Capabilities: &corev1.Capabilities{
-										Drop: []corev1.Capability{"All"},
+										Drop: []corev1.Capability{capabilityAll},
 									},
 								},
-								Command: []string{"/bin/bash", "-c", logRotateCmd},
+								Command: []string{bashShell, "-c", logRotateCmd},
 								VolumeMounts: []corev1.VolumeMount{
 									utils.LogsDirVolumeMount,
 									utils.LogRotateDirVolumeMount,
@@ -1359,7 +1368,7 @@ func (r *driverReconcile) reconcileNodePluginCsiAddonsNetworkPolicy() error {
 		}
 		np.Spec = networkingv1.NetworkPolicySpec{
 			PodSelector: metav1.LabelSelector{
-				MatchLabels: map[string]string{"app": np.Name},
+				MatchLabels: map[string]string{appLabelKey: np.Name},
 			},
 			Ingress: []networkingv1.NetworkPolicyIngressRule{{
 				From: []networkingv1.NetworkPolicyPeer{{
@@ -1417,7 +1426,7 @@ func (r *driverReconcile) reconcileNodePluginDaemonSet() error {
 
 		daemonSet.Spec = appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"app": appName},
+				MatchLabels: map[string]string{appLabelKey: appName},
 			},
 			UpdateStrategy: ptr.Deref(pluginSpec.UpdateStrategy, defaultDaemonSetUpdateStrategy),
 			Template: corev1.PodTemplateSpec{
@@ -1425,7 +1434,7 @@ func (r *driverReconcile) reconcileNodePluginDaemonSet() error {
 					Labels: utils.Call(func() map[string]string {
 						podLabels := map[string]string{}
 						maps.Copy(podLabels, pluginSpec.Labels)
-						podLabels["app"] = appName
+						podLabels[appLabelKey] = appName
 						if r.driver.Spec.Liveness != nil {
 							podLabels["contains"] = fmt.Sprintf("%s-metrics", appName)
 						}
@@ -1454,7 +1463,7 @@ func (r *driverReconcile) reconcileNodePluginDaemonSet() error {
 									Privileged: ptr.To(true),
 									Capabilities: &corev1.Capabilities{
 										Add:  []corev1.Capability{"SYS_ADMIN"},
-										Drop: []corev1.Capability{"All"},
+										Drop: []corev1.Capability{capabilityAll},
 									},
 									AllowPrivilegeEscalation: ptr.To(true),
 								},
@@ -1569,7 +1578,7 @@ func (r *driverReconcile) reconcileNodePluginDaemonSet() error {
 								SecurityContext: &corev1.SecurityContext{
 									Privileged: ptr.To(true),
 									Capabilities: &corev1.Capabilities{
-										Drop: []corev1.Capability{"All"},
+										Drop: []corev1.Capability{capabilityAll},
 									},
 								},
 								Args: utils.DeleteZeroValues(
@@ -1601,7 +1610,7 @@ func (r *driverReconcile) reconcileNodePluginDaemonSet() error {
 								SecurityContext: &corev1.SecurityContext{
 									Privileged: ptr.To(true),
 									Capabilities: &corev1.Capabilities{
-										Drop: []corev1.Capability{"All"},
+										Drop: []corev1.Capability{capabilityAll},
 									},
 								},
 								Args: utils.DeleteZeroValues(
@@ -1633,17 +1642,17 @@ func (r *driverReconcile) reconcileNodePluginDaemonSet() error {
 						if logRotationEnabled {
 							resources := ptr.Deref(pluginSpec.Resources.LogRotator, corev1.ResourceRequirements{})
 							containers = append(containers, corev1.Container{
-								Name:            "log-rotator",
+								Name:            logRotatorContainer,
 								Image:           r.images["plugin"],
 								ImagePullPolicy: imagePullPolicy,
 								Resources:       resources,
 								SecurityContext: &corev1.SecurityContext{
 									Privileged: ptr.To(true),
 									Capabilities: &corev1.Capabilities{
-										Drop: []corev1.Capability{"All"},
+										Drop: []corev1.Capability{capabilityAll},
 									},
 								},
-								Command: []string{"/bin/bash", "-c", logRotateCmd},
+								Command: []string{bashShell, "-c", logRotateCmd},
 								VolumeMounts: []corev1.VolumeMount{
 									utils.LogsDirVolumeMount,
 									utils.LogRotateDirVolumeMount,
@@ -1816,7 +1825,7 @@ func (r *driverReconcile) getControllerPluginReplicas(
 		return specReplicas
 	}
 
-	var replicas int32 = defaultControllerPluginReplicas
+	var replicas = defaultControllerPluginReplicas
 	nodeList := &corev1.NodeList{}
 	if err := r.List(r.ctx, nodeList); err != nil {
 		log.Error(err, "Failed to list nodes for replica calculation")

--- a/internal/controller/driver_controller_test.go
+++ b/internal/controller/driver_controller_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Driver Controller", func() {
 
 		typeNamespacedName := types.NamespacedName{
 			Name:      resourceName,
-			Namespace: "default", // TODO(user):Modify as needed
+			Namespace: defaultNamespace, // TODO(user):Modify as needed
 		}
 		driver := &csiv1.Driver{}
 

--- a/internal/utils/core_test.go
+++ b/internal/utils/core_test.go
@@ -22,6 +22,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const (
+	testValueNew  = "new"
+	testValueKeep = "keep"
+)
+
 // Dummy source and destination structs for testing
 type sourceItem struct {
 	ID    string
@@ -58,25 +63,25 @@ func TestMapMergeByKey(t *testing.T) {
 				{ID: "a", Value: "old"},
 			},
 			src: []sourceItem{
-				{ID: "a", Value: "new"},
+				{ID: "a", Value: testValueNew},
 			},
 			expected: []destItem{
-				{ID: "a", Value: "new"},
+				{ID: "a", Value: testValueNew},
 			},
 		},
 		{
 			name: "append and replace mix",
 			dest: []destItem{
-				{ID: "x", Value: "keep"},
+				{ID: "x", Value: testValueKeep},
 				{ID: "a", Value: "old"},
 			},
 			src: []sourceItem{
-				{ID: "a", Value: "new"},
+				{ID: "a", Value: testValueNew},
 				{ID: "b", Value: "added"},
 			},
 			expected: []destItem{
-				{ID: "x", Value: "keep"},
-				{ID: "a", Value: "new"},
+				{ID: "x", Value: testValueKeep},
+				{ID: "a", Value: testValueNew},
 				{ID: "b", Value: "added"},
 			},
 		},
@@ -85,10 +90,10 @@ func TestMapMergeByKey(t *testing.T) {
 			dest: []destItem{},
 			src: []sourceItem{
 				{ID: "", Value: "skip"},
-				{ID: "b", Value: "keep"},
+				{ID: "b", Value: testValueKeep},
 			},
 			expected: []destItem{
-				{ID: "b", Value: "keep"},
+				{ID: "b", Value: testValueKeep},
 			},
 		},
 		{

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -22,7 +22,7 @@ import (
 	"os/exec"
 	"strings"
 
-	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive
+	"github.com/onsi/ginkgo/v2"
 )
 
 const (
@@ -35,7 +35,7 @@ const (
 )
 
 func warnError(err error) {
-	_, fErr := fmt.Fprintf(GinkgoWriter, "warning: %v\n", err)
+	_, fErr := fmt.Fprintf(ginkgo.GinkgoWriter, "warning: %v\n", err)
 	if fErr != nil {
 		panic(fErr)
 	}
@@ -56,7 +56,7 @@ func Run(cmd *exec.Cmd) ([]byte, error) {
 	cmd.Dir = dir
 
 	if err := os.Chdir(cmd.Dir); err != nil {
-		_, fErr := fmt.Fprintf(GinkgoWriter, "chdir dir: %s\n", err)
+		_, fErr := fmt.Fprintf(ginkgo.GinkgoWriter, "chdir dir: %s\n", err)
 		if fErr != nil {
 			panic(fErr)
 		}
@@ -64,7 +64,7 @@ func Run(cmd *exec.Cmd) ([]byte, error) {
 
 	cmd.Env = append(os.Environ(), "GO111MODULE=on")
 	command := strings.Join(cmd.Args, " ")
-	_, err := fmt.Fprintf(GinkgoWriter, "running: %s\n", command)
+	_, err := fmt.Fprintf(ginkgo.GinkgoWriter, "running: %s\n", command)
 	if err != nil {
 		return nil, err
 	}
@@ -150,6 +150,6 @@ func GetProjectDir() (string, error) {
 	if err != nil {
 		return wd, err
 	}
-	wd = strings.Replace(wd, "/test/e2e", "", -1)
+	wd = strings.ReplaceAll(wd, "/test/e2e", "")
 	return wd, nil
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi-operator! -->

# Describe what this PR does

Upgrade golangci-lint from v1.63.4 to v2.13.2 and migrate the configuration to the golangci-lint v2 format.

This PR:

* Updates the golangci-lint module path and command-line syntax.
* Moves `gofmt` and `goimports` from linters to formatters.
* Removes linters that are no longer available in golangci-lint v2.
* Fixes findings reported by `goconst` and `staticcheck`.
* Replaces the Ginkgo dot import with a qualified import.
* Replaces `strings.Replace(..., -1)` with `strings.ReplaceAll`.

# Is there anything that requires special attention

No.The change does not modify the operator APIs or generated resources.

Validation performed:

* `make golangci-lint`
* `make test`
* `make build`
* `go mod verify`

All completed checks passed.

# Related issues

None.

# Future concerns

None.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi-operator/blob/main/docs/development-guide.md#development-workflow).
* [ ] [Pending release notes](https://github.com/ceph/ceph-csi-operator/blob/main/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.