### PR TITLE
operator: bump csi-addons, csi-plugin and csi-sidecars to the latest version

### DIFF
--- a/docs/features/rbd-snapshot-metadata.md
+++ b/docs/features/rbd-snapshot-metadata.md
@@ -21,10 +21,10 @@ of the RBD controller plugin with the `external-snapshot-metadata` sidecar.
 
 Users need to perform the following manual setup:
 
-1. Install the [SnapshotMetadataService CRD](https://github.com/kubernetes-csi/external-snapshot-metadata/blob/v1.0.0/client/config/crd/cbt.storage.k8s.io_snapshotmetadataservices.yaml)
+1. Install the [SnapshotMetadataService CRD](https://github.com/kubernetes-csi/external-snapshot-metadata/blob/v1.1.0/client/config/crd/cbt.storage.k8s.io_snapshotmetadataservices.yaml)
 
    ```bash
-   kubectl create -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshot-metadata/refs/tags/v1.0.0/client/config/crd/cbt.storage.k8s.io_snapshotmetadataservices.yaml
+   kubectl create -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshot-metadata/refs/tags/v1.1.0/client/config/crd/cbt.storage.k8s.io_snapshotmetadataservices.yaml
    ```
 
 2. Create a Service to expose the RBD driver pod

--- a/internal/controller/defaults.go
+++ b/internal/controller/defaults.go
@@ -35,7 +35,7 @@ var imageDefaults = map[string]string{
 	"registrar":         "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0",
 	"snapshot-metadata": "registry.k8s.io/sig-storage/csi-snapshot-metadata:v1.0.0",
 	"plugin":            "quay.io/cephcsi/cephcsi:v3.17.0",
-	"addons":            "quay.io/csiaddons/k8s-sidecar:v0.14.0",
+	"addons":            "quay.io/csiaddons/k8s-sidecar:v0.15.0",
 }
 
 const (

--- a/internal/controller/defaults.go
+++ b/internal/controller/defaults.go
@@ -28,13 +28,13 @@ import (
 )
 
 var imageDefaults = map[string]string{
-	"provisioner":       "registry.k8s.io/sig-storage/csi-provisioner:v6.2.0",
+	"provisioner":       "registry.k8s.io/sig-storage/csi-provisioner:v6.3.0",
 	"attacher":          "registry.k8s.io/sig-storage/csi-attacher:v4.12.0",
-	"resizer":           "registry.k8s.io/sig-storage/csi-resizer:v2.1.0",
-	"snapshotter":       "registry.k8s.io/sig-storage/csi-snapshotter:v8.5.0",
+	"resizer":           "registry.k8s.io/sig-storage/csi-resizer:v2.2.1",
+	"snapshotter":       "registry.k8s.io/sig-storage/csi-snapshotter:v8.6.0",
 	"registrar":         "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0",
-	"snapshot-metadata": "registry.k8s.io/sig-storage/csi-snapshot-metadata:v1.0.0",
-	"plugin":            "quay.io/cephcsi/cephcsi:v3.17.0",
+	"snapshot-metadata": "registry.k8s.io/sig-storage/csi-snapshot-metadata:v1.1.0",
+	"plugin":            "quay.io/cephcsi/cephcsi:v3.17.1",
 	"addons":            "quay.io/csiaddons/k8s-sidecar:v0.15.0",
 }
 

--- a/test/scripts/install-csi-addons.sh
+++ b/test/scripts/install-csi-addons.sh
@@ -11,7 +11,7 @@ SCRIPT_DIR="$(dirname "${0}")"
 # shellcheck disable=SC1091
 [ ! -e "${SCRIPT_DIR}"/utils.sh ] || source "${SCRIPT_DIR}"/utils.sh
 
-CSI_ADDONS_VERSION=${CSI_ADDONS_VERSION:-"v0.14.0"}
+CSI_ADDONS_VERSION=${CSI_ADDONS_VERSION:-"v0.15.0"}
 CSI_ADDONS_NAMESPACE=${CSI_ADDONS_NAMESPACE:-"csi-addons-system"}
 
 CSI_ADDONS_URL="https://raw.githubusercontent.com/csi-addons/kubernetes-csi-addons/${CSI_ADDONS_VERSION}/deploy/controller"


### PR DESCRIPTION
# Describe what this PR does #

This PR updates the default versions for multiple CSI sidecars, the `cephcsi` plugin, and the CSI-Addons sidecar image. All new versions were verified to be available. `csi-attacher` and `csi- node-driver-registrar` have latest versions but the images are not available.

**Summary of version bumps:**
* **CSI-Addons sidecar:** `v0.14.0` → `v0.15.0`
* **csi-provisioner:** `v6.2.0` → `v6.3.0`
* **csi-resizer:** `v2.1.0` → `v2.2.1`
* **csi-snapshotter:** `v8.5.0` → `v8.6.0`
* **csi-snapshot-metadata:** `v1.0.0` → `v1.1.0`
* **cephcsi plugin:** `v3.17.0` → `v3.17.1`

This updates:
- The operator default images in `internal/controller/defaults.go`
- The CSI-Addons test install script in `test/scripts/install-csi-addons.sh`
- The snapshot-metadata documentation in `docs/snapshot-metadata.md`
- The custom image documentation in `docs/custom-images.md`

## Is there anything that requires special attention ##

These are version bumps only and do not change the operator API or CRD schema.

## Related issues ##

None.

## Future concerns ##

None.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com)
* [ ] [Pending release notes](https://github.com) updated with breaking and/or notable changes for the next major release.
* [x] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.